### PR TITLE
fix duplicate "horizontally" in documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1413,7 +1413,7 @@ Example: &lt;div class=&quot;padding-left-medium margin-bottom-none&quot;&gt;
 </pre>
     <p>
       You can also use <code>margin-[x|y|xy]-auto</code> to set automatic margins horizontally
-      and/or horizontally.
+      and/or vertically.
     </p>
 
     <!--********************************************************************************************


### PR DESCRIPTION
Not a big deal, just one minor issue with one sentence in the excellent documentation.