### PR TITLE
Update npm install documentation

### DIFF
--- a/docs/installing.html
+++ b/docs/installing.html
@@ -66,7 +66,7 @@
 </code></pre>
 <h3 id="npm">NPM</h3>
 <p>If you’re using NPM, you can install Shoelace by running:</p>
-<pre><code>npm install --save-dev shoelace-css
+<pre><code>npm install shoelace-css
 </code></pre>
     </div>
   </main>


### PR DESCRIPTION
The documentation suggests installing via npm as a dev dependency.

```
npm install --save-dev shoelace-css
```

It should **not be a dev dependency**, that is usually for build tools, unit tests, etc. You should have used `--save` instead.

As of npm5, that can actually even be omitted. [`npm install` will `--save` by default](http://blog.npmjs.org/post/161081169345/v500).