### PR TITLE
Unprefix pseudo elements

### DIFF
--- a/source/css/content.css
+++ b/source/css/content.css
@@ -183,20 +183,13 @@ ul ul {
 * Placeholders
 ***************************************************************************************************/
 
-::-webkit-input-placeholder { color: var(--placeholder-color); }
-::-moz-placeholder { color: var(--placeholder-color); }
-:-ms-input-placeholder { color: var(--placeholder-color); }
-:-moz-placeholder { color: var(--placeholder-color); }
+::placeholder {
+  color: var(--placeholder-color);
+}
 
 /***************************************************************************************************
 * Selections
 ***************************************************************************************************/
-
-::-moz-selection {
-  background-color: var(--selection-bg-color);
-  color: var(--selection-color);
-  text-shadow: none !important;
-}
 
 ::selection {
   background-color: var(--selection-bg-color);


### PR DESCRIPTION
All prefixing should be handled by Autoprefixer, even weird pseudo elements and classes. Ideally I think shoelace should always write bleeding-edge spec-compliant CSS.

Rest assured that:
- [`::-moz-selection` will eventually be unprefixed](https://bugzilla.mozilla.org/show_bug.cgi?id=509958). Support is otherwise good.
- [`:-moz-placeholder` and friends are no longer a standard](https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-placeholder). `::placeholder` is the standard and well supported.
