### PR TITLE
fix inability to use switch components w/keyboard controls

### DIFF
--- a/source/css/switches.css
+++ b/source/css/switches.css
@@ -17,10 +17,19 @@
 
 .switch {
   font-size: var(--switch-font-size);
+  position: relative;
 }
 
 .switch input {
-  display: none;
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  background: none;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  padding: 0;
 }
 
 .switch input + label {
@@ -75,6 +84,10 @@
 .switch input:disabled + label {
   opacity: .5;
   cursor: not-allowed;
+}
+
+.switch input:focus + label {
+  outline: 1px dotted;
 }
 
 .switch-small {


### PR DESCRIPTION
the switch component was originally using a `display: none` to hide visually hide the native checkbox element. Using this method resulted in the checkbox being inaccessible to keyboard users.

By updating the `.switch input` selector to instead utilize a ruleset that will shrink and visually hide the checkbox from view (see html5 boilerplate’s visuallyhidden class), the checkbox will remain visually hidden, but now allow keyboards and assistive technology to access it.

A new selector `.switch input: focus + label` was also added to provide visual context for when a switch component has received keyboard focus.  Without this selector there would be no indicator, for sighted keyboard users, that a switch was the currently focused element.