### PR TITLE
add focus states

### DIFF
--- a/source/css/badges.css
+++ b/source/css/badges.css
@@ -22,7 +22,8 @@
   display: none;
 }
 
-a.badge:hover {
+a.badge:hover,
+a.badge:focus {
   color: var(--badge-color);
   text-decoration: none;
   box-shadow: var(--badge-box-shadow-hover);
@@ -50,13 +51,15 @@ a.badge:hover {
 }
 
 .badge-light,
-a.badge-light:hover {
+a.badge-light:hover,
+a.badge-light:focus {
   color: var(--state-dark);
   background-color: var(--state-light);
 }
 
 .badge-dark,
-a.badge-dark:hover {
+a.badge-dark:hover,
+a.badge-dark:focus {
   color: var(--state-light);
   background-color: var(--state-dark);
 }

--- a/source/css/buttons.css
+++ b/source/css/buttons.css
@@ -78,13 +78,17 @@ button,
 }
 
 button:hover,
-.button:hover {
+button:focus,
+.button:hover,
+.button:focus {
   color: var(--button-color);
   text-decoration: none;
 }
 
 button:hover:not(:disabled),
-.button:hover:not(.disabled) {
+button:focus:not(:disabled),
+.button:hover:not(.disabled),
+.button:focus:not(.disabled) {
   color: var(--button-color);
   box-shadow: var(--button-box-shadow-hover);
 }
@@ -109,7 +113,8 @@ label.button input[type="file"] {
 
 /* Loader buttons */
 .button-loader,
-.button-loader:hover {
+.button-loader:hover,
+.button-loader:focus {
   position: relative;
   min-width: calc(var(--button-loader-size) * 2);
   color: transparent !important;
@@ -164,14 +169,18 @@ label.button input[type="file"] {
 
 .button-light,
 button.button-light:hover:not(:disabled),
-.button-light:hover:not(.disabled) {
+button.button-light:focus:not(:disabled),
+.button-light:hover:not(.disabled),
+.button-light:focus:not(.disabled) {
   color: var(--state-dark);
   background-color: var(--state-light);
 }
 
 .button-dark,
 button.button-dark:hover:not(:disabled),
-.button-dark:hover:not(.disabled) {
+button.button-dark:focus:not(:disabled),
+.button-dark:hover:not(.disabled),
+.button-dark:focus:not(.disabled) {
   color: var(--state-light);
   background-color: var(--state-dark);
 }

--- a/source/css/content.css
+++ b/source/css/content.css
@@ -90,7 +90,8 @@ a {
   text-decoration: var(--link-text-decoration);
 }
 
-a:hover {
+a:hover,
+a:focus {
   color: var(--link-color-hover);
   text-decoration: var(--link-text-decoration-hover);
 }

--- a/source/css/tabs.css
+++ b/source/css/tabs.css
@@ -38,7 +38,8 @@
   display: inline-block;
 }
 
-.tabs-nav a:hover {
+.tabs-nav a:hover,
+.tabs-nav a:focus {
   color: var(--tab-color-hover);
   background-color: var(--tab-bg-color-hover);
   text-decoration: none;


### PR DESCRIPTION
add `:focus` selectors to `<a>` and `<button>` elements Set focus states for `<a>` and `<button>` elements to provide parity for mouse and keyboard interactions.
