### PR TITLE
Keyboard accessibility updates for docs

### DIFF
--- a/docs/alerts.html
+++ b/docs/alerts.html
@@ -12,6 +12,7 @@
   <title>Alerts</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -83,7 +84,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/attribution.html
+++ b/docs/attribution.html
@@ -12,6 +12,7 @@
   <title>Attribution</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -68,7 +69,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/badges.html
+++ b/docs/badges.html
@@ -12,6 +12,7 @@
   <title>Badges</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -112,7 +113,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/browser-support.html
+++ b/docs/browser-support.html
@@ -12,6 +12,7 @@
   <title>Browser Support</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -73,7 +74,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/buttons.html
+++ b/docs/buttons.html
@@ -12,6 +12,7 @@
   <title>Buttons</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -169,7 +170,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/content.html
+++ b/docs/content.html
@@ -12,6 +12,7 @@
   <title>Content</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -196,7 +197,7 @@ PRINT &quot;SHOELACE IS AWESOME&quot;
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/customizing.html
+++ b/docs/customizing.html
@@ -12,6 +12,7 @@
   <title>Customizing</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -110,7 +111,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/dropdowns.html
+++ b/docs/dropdowns.html
@@ -12,6 +12,7 @@
   <title>Dropdowns</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -196,7 +197,7 @@ $(&#39;#my-dropdown&#39;).removeClass(&#39;active&#39;);
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/file-buttons.html
+++ b/docs/file-buttons.html
@@ -12,6 +12,7 @@
   <title>File Buttons</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -145,7 +146,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/forms.html
+++ b/docs/forms.html
@@ -13,6 +13,7 @@
   <title>Forms</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -28,7 +29,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -50,7 +51,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -638,7 +639,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/grid-system.html
+++ b/docs/grid-system.html
@@ -12,6 +12,7 @@
   <title>Grid System</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -303,7 +304,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/icons.html
+++ b/docs/icons.html
@@ -13,6 +13,7 @@
   <title>Icons</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -28,7 +29,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -50,7 +51,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -90,7 +91,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/installing.html
+++ b/docs/installing.html
@@ -12,6 +12,7 @@
   <title>Installing</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,13 +50,13 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
           <h2 id="installing">Installing</h2>
 <p>There are two ways to use Shoelace. If you want to get things up and running quickly, use the <code>dist/</code> version or the <a href="#cdn">CDN version</a>. This version isn’t customizable, nor can you use future CSS features with it. It’s primarily intended for prototyping.</p>
-<p>If you’re developing a production app, you should <a href="#building-from-source">build Shoelace from source</a>. This version is completely customizable, modular, and let’s you use future CSS features <em>today</em>.</p>
+<p>If you’re developing a production app, you should <a href="#building-from-source">build Shoelace from source</a>. This version is completely customizable, modular, and lets you use future CSS features <em>today</em>.</p>
 <p><strong>Note:</strong> To make certain components interactive (e.g. dropdowns and tabs), you’ll need to load <a href="https://cdnjs.com/libraries/jquery/">jQuery</a> or <a href="https://cdnjs.com/libraries/zepto/">Zepto</a> before <code>shoelace.js</code>.</p>
 <h3 id="cdn">CDN</h3>
 <p>This is the best approach for prototyping, however, this version isn’t customizable and doesn’t support future CSS features. To load Shoelace via CDN, add this to your <code>&lt;head&gt;</code>:</p>
@@ -78,7 +79,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/loaders.html
+++ b/docs/loaders.html
@@ -12,6 +12,7 @@
   <title>Loaders</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -126,7 +127,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/progress-bars.html
+++ b/docs/progress-bars.html
@@ -12,6 +12,7 @@
   <title>Progress Bars</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -168,7 +169,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/switches.html
+++ b/docs/switches.html
@@ -12,6 +12,7 @@
   <title>Switches</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -194,7 +195,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/tables.html
+++ b/docs/tables.html
@@ -12,6 +12,7 @@
   <title>Tables</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -137,7 +138,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/tabs.html
+++ b/docs/tabs.html
@@ -12,6 +12,7 @@
   <title>Tabs</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -199,7 +200,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/docs/utilities.html
+++ b/docs/utilities.html
@@ -12,6 +12,7 @@
   <title>Utilities</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>
@@ -27,7 +28,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -49,7 +50,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">
@@ -265,7 +266,7 @@ mar-[t|r|b|l|x|y]-[0|xs|sm|md|lg|xl]
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/source/css/_docs.css
+++ b/source/css/_docs.css
@@ -2,6 +2,25 @@ body {
   border-top: solid .3rem #0074d9;
 }
 
+.skip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: .25rem .5rem;
+  background-color: #0074d9;
+  color: #fff;
+  transition: all .1s;
+  transform: translateY(-100%);
+}
+
+.skip:hover,
+.skip:focus {
+  text-decoration: none;
+  color: #fff;
+  background-color: #0068c3;
+  transform: none;
+}
+
 #head {
   padding: 0 2rem;
   margin: 2rem 0;

--- a/source/layouts/default.html
+++ b/source/layouts/default.html
@@ -62,7 +62,7 @@
       </div>
   </main>
 
-  <footer id="foot">
+  <footer id="foot" role="contentinfo">
     <a href="../index.html">
       <img src="../source/img/wordmark.svg" alt="Shoelace logo">
     </a>

--- a/source/layouts/default.html
+++ b/source/layouts/default.html
@@ -15,6 +15,7 @@
   <title>{{title}}</title>
 </head>
 <body>
+  <a href="#content" class="skip">Skip to content</a>
 
   <header id="head" class="text-center">
     <h1>

--- a/source/layouts/default.html
+++ b/source/layouts/default.html
@@ -31,7 +31,7 @@
 
   <main class="container">
     <div class="row">
-      <div class="col-md-3">
+      <nav class="col-md-3">
         <ul id="nav">
           <li><a href="installing.html">Installing</a></li>
           <li><a href="customizing.html">Customizing</a></li>
@@ -53,7 +53,7 @@
           <li><a href="browser-support.html">Browser Support</a></li>
           <li><a href="attribution.html">Attribution</a></li>
         </ul>
-      </div>
+      </nav>
 
       <div class="col-md-9">
         <div id="content">


### PR DESCRIPTION
### Pull Request Summary

This PR adds support for keyboard users to navigate the docs.

- Adds [skip to](https://webaim.org/techniques/skipnav/) link.
- Makes sidebar navigation a `nav` element so keyboard users can navigate to it via landmarks menu.
- Adds `role="contentinfo"` to the `footer` element so keyboard users can navigate to it via landmarks menu.

---

Before embarking on a large, complex, or controversial feature, please open an issue so we can discuss it. Someone may be working on it already, it might not align with the project's roadmap, or we might be able to improve on your idea before you spend a lot of time working on it.

If your PR doesn't get accepted, don't let it get you down. Many don't. It doesn't mean I don't value your idea or contribution, it just means that it doesn't align with my vision for the project. As the maintainer, I'll do my best to explain why every PR doesn't get accepted.
