### PR TITLE
fix newlines in textareas on Firefox

### DIFF
--- a/source/css/forms.css
+++ b/source/css/forms.css
@@ -141,7 +141,7 @@ textarea.input-xl {
   height: auto;
   resize: vertical;
   line-height: var(--line-height);
-  white-space: normal;
+  white-space: pre-wrap;
 }
 
 /* Range */


### PR DESCRIPTION
Newlines aren't working in Firefox.  This is because `white-space` is set to `normal`.  You can see this on the [documentation page for forms](https://shoelace.style/docs/forms.html).

According to the [spec](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) it shouldn't work in Chrome either, but it does.

But it is simple enough to fix.  Alternatively, you could just remove it altogether.