### PR TITLE
Switch RawGit to unpkg

### DIFF
--- a/docs/alerts.html
+++ b/docs/alerts.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Alerts</title>
 </head>
 <body>

--- a/docs/attribution.html
+++ b/docs/attribution.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Attribution</title>
 </head>
 <body>

--- a/docs/badges.html
+++ b/docs/badges.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Badges</title>
 </head>
 <body>

--- a/docs/browser-support.html
+++ b/docs/browser-support.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Browser Support</title>
 </head>
 <body>

--- a/docs/buttons.html
+++ b/docs/buttons.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Buttons</title>
 </head>
 <body>

--- a/docs/content.html
+++ b/docs/content.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Content</title>
 </head>
 <body>

--- a/docs/customizing.html
+++ b/docs/customizing.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Customizing</title>
 </head>
 <body>

--- a/docs/dropdowns.html
+++ b/docs/dropdowns.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Dropdowns</title>
 </head>
 <body>

--- a/docs/file-buttons.html
+++ b/docs/file-buttons.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>File Buttons</title>
 </head>
 <body>

--- a/docs/forms.html
+++ b/docs/forms.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css">
   <title>Forms</title>
 </head>

--- a/docs/grid-system.html
+++ b/docs/grid-system.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Grid System</title>
 </head>
 <body>

--- a/docs/icons.html
+++ b/docs/icons.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css">
   <title>Icons</title>
 </head>

--- a/docs/installing.html
+++ b/docs/installing.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Installing</title>
 </head>
 <body>

--- a/docs/loaders.html
+++ b/docs/loaders.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Loaders</title>
 </head>
 <body>

--- a/docs/progress-bars.html
+++ b/docs/progress-bars.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Progress Bars</title>
 </head>
 <body>

--- a/docs/switches.html
+++ b/docs/switches.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Switches</title>
 </head>
 <body>

--- a/docs/tables.html
+++ b/docs/tables.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Tables</title>
 </head>
 <body>

--- a/docs/tabs.html
+++ b/docs/tabs.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Tabs</title>
 </head>
 <body>

--- a/docs/utilities.html
+++ b/docs/utilities.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Utilities</title>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_homepage.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   <title>Shoelace.css – a back to the basics CSS starter kit</title>
 </head>
 <body>

--- a/source/layouts/default.html
+++ b/source/layouts/default.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="../source/img/favicon.png">
   <link rel="stylesheet" href="../dist/shoelace.css">
   <link rel="stylesheet" href="../source/css/_docs.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/AGMStudio/prism-theme-one-dark/f81fe477/prism-onedark.css">
+  <link rel="stylesheet" href="https://unpkg.com/prism-theme-one-dark@1.0.0/prism-onedark.css" integrity="sha384-WBhzd+87GQqNnqPLNAn5C7FAa8F/UuNpjW2vcLo8iVyvvT3LxuGZh6xoQYPTq0Tw" crossorigin="anonymous">
   {{#each stylesheets}}
   <link rel="stylesheet" href="{{.}}">
   {{/each}}


### PR DESCRIPTION
[RawGit](https://rawgit.com/) is closing down and may stop serving resources October 2019. This just moves away from the RawGit to use [unpkg](https://unpkg.com/) instead. Using unpkg is possible because [the One Dark Prism theme](https://github.com/AGMStudio/prism-theme-one-dark) is [published on npm](https://www.npmjs.com/package/prism-theme-one-dark).

I pinned it to version 1.0.0, which matches the commit that was previously pinned on RawGit (https://github.com/AGMStudio/prism-theme-one-dark/commit/f81fe477b2202524e7b06933e951fd1bc6b8116b).

Also added the subresource integrity hash (which in turn requires crossorigin) so even if someone manages to republish the package with something nefarious it shouldn’t go through.