### PR TITLE
Switch lock array to set operations

### DIFF
--- a/src/utilities/scroll.ts
+++ b/src/utilities/scroll.ts
@@ -6,8 +6,7 @@ const locks = new Set();
 // Prevents body scrolling. Keeps track of which elements requested a lock so multiple levels of locking are possible
 // without premature unlocking.
 //
-export function lockBodyScrolling(lockingEl: HTMLElement | null) {
-  if (!lockingEl) return
+export function lockBodyScrolling(lockingEl: HTMLElement) {
   locks.add(lockingEl);
   document.body.classList.add('sl-scroll-lock');
 }

--- a/src/utilities/scroll.ts
+++ b/src/utilities/scroll.ts
@@ -1,25 +1,24 @@
 import { getOffset } from './offset';
 
-let locks = [];
+const locks = new Set();
 
 //
 // Prevents body scrolling. Keeps track of which elements requested a lock so multiple levels of locking are possible
 // without premature unlocking.
 //
-export function lockBodyScrolling(lockingEl: HTMLElement) {
-  if (lockingEl && !locks.includes(lockingEl)) {
-    locks.push(lockingEl);
-    document.body.classList.add('sl-scroll-lock');
-  }
+export function lockBodyScrolling(lockingEl: HTMLElement | null) {
+  if (!lockingEl) return
+  locks.add(lockingEl);
+  document.body.classList.add('sl-scroll-lock');
 }
 
 //
 // Unlocks body scrolling. Scrolling will only be unlocked once all elements that requested a lock call this method.
 //
 export function unlockBodyScrolling(lockingEl: HTMLElement) {
-  locks = locks.filter(el => el !== lockingEl);
+  locks.delete(lockingEl);
 
-  if (locks.length === 0) {
+  if (locks.size === 0) {
     document.body.classList.remove('sl-scroll-lock');
   }
 }


### PR DESCRIPTION
This swaps the locks array to a Set.

`Set` is supported by IE11 and all modern browsers.

`Set` is also significantly more performant.

Also, adjusted the `lockBodyScrolling` function to accept `null` since there was already a boolean check that the `lockingEl` was defined.