### PR TITLE
feat(details) allow for isolated styling of border

### DIFF
--- a/src/components/details/details.scss
+++ b/src/components/details/details.scss
@@ -1,12 +1,16 @@
 @import 'component';
 
 /**
+ * @prop --border-color: The color of the header border.
+ * @prop --border-radius: The border radius of the component.
  * @prop --hide-duration: The length of the hide transition.
  * @prop --hide-timing-function: The timing function (easing) to use for the hide transition.
  * @prop --show-duration: The length of the show transition.
  * @prop --show-timing-function: The timing function (easing) to use for the show transition.
  */
 :host {
+  --border-color: var(--sl-color-gray-90);
+  --border-radius: var(--sl-border-radius-medium);
   --hide-duration: var(--sl-transition-medium);
   --hide-timing-function: ease;
   --show-duration: var(--sl-transition-medium);
@@ -16,8 +20,8 @@
 }
 
 .details {
-  border: solid 1px var(--sl-color-gray-90);
-  border-radius: var(--sl-border-radius-medium);
+  border: solid 1px var(--border-color);
+  border-radius: var(--border-radius);
 }
 
 .details--disabled {


### PR DESCRIPTION
Hi!

Not sure if my thinking is right it felt wrong to have to change CSS variables specific to your theme e.g. `...-gray-90`. It's nice for a default value but when consuming the component inside of an existing app with other 3rd party components it's maybe cleaner this way?

I know we can tackle this with `::part()` but it seems like a "last resort". Might be wrong here and need to get accustomed to this still.