### PR TITLE
Fixes #135 - handle mousedown events outside shadow roots

### DIFF
--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -217,10 +217,9 @@ export class Dropdown {
   }
 
   handleDocumentMouseDown(event: MouseEvent) {
-    const target = event.target as HTMLElement;
-
     // Close when clicking outside of the close element
-    if (target.closest(this.containingElement.tagName.toLowerCase()) !== this.containingElement) {
+    const path = event.composedPath() as Array<EventTarget>;
+    if (!path.includes(this.containingElement)) {
       this.hide();
       return;
     }


### PR DESCRIPTION
Uses the composedPath() array to find the closest matching elements an event was triggered on when checking a mousedown event happened outside of a component.

composedPath() is preferred over closest() since it pierces shadow DOM boundaries.