### PR TITLE
Fixes #148 - prevents recursive calls to observer

### DIFF
--- a/src/components/tab-group/tab-group.tsx
+++ b/src/components/tab-group/tab-group.tsx
@@ -59,7 +59,15 @@ export class TabGroup {
     focusVisible.observe(this.tabGroup);
 
     // Update aria labels if the DOM changes
-    this.mutationObserver = new MutationObserver(() => setTimeout(() => this.setAriaLabels()));
+    this.mutationObserver = new MutationObserver(mutations => {
+      if (
+        mutations.some(mutation => {
+          return !['arial-labeledby', 'aria-controls'].includes(mutation.attributeName);
+        })
+      ) {
+        setTimeout(() => this.setAriaLabels());
+      }
+    });
     this.mutationObserver.observe(this.host, { attributes: true, childList: true, subtree: true });
   }
 

--- a/src/components/tab-group/tab-group.tsx
+++ b/src/components/tab-group/tab-group.tsx
@@ -62,7 +62,7 @@ export class TabGroup {
     this.mutationObserver = new MutationObserver(mutations => {
       if (
         mutations.some(mutation => {
-          return !['arial-labeledby', 'aria-controls'].includes(mutation.attributeName);
+          return !['aria-labeledby', 'aria-controls'].includes(mutation.attributeName);
         })
       ) {
         setTimeout(() => this.setAriaLabels());
@@ -141,7 +141,7 @@ export class TabGroup {
       const panel = panels.find(el => el.name === tab.panel);
       if (panel) {
         tab.setAttribute('aria-controls', panel.getAttribute('id'));
-        panel.setAttribute('arial-labeledby', tab.getAttribute('id'));
+        panel.setAttribute('aria-labeledby', tab.getAttribute('id'));
       }
     });
   }


### PR DESCRIPTION
Uses a block list for the attributes that shouldn't trigger the observer. It may be better to use an allow list since the observer is still called unnecessarily for e.g. `style` attribute changes.