### PR TITLE
Fixes #153 - Tab Group - set active tab when element is visible

### DIFF
--- a/src/components/tab-group/tab-group.tsx
+++ b/src/components/tab-group/tab-group.tsx
@@ -53,9 +53,16 @@ export class TabGroup {
   @Event() slTabHide: EventEmitter;
 
   componentDidLoad() {
-    // Set initial tab state
-    this.setAriaLabels();
-    this.setActiveTab(this.getActiveTab() || this.getAllTabs()[0], false);
+    // Set initial tab state when the tabs first become visible
+    const observer = new IntersectionObserver((entries, observer) => {
+      if (entries[0].intersectionRatio > 0) {
+        this.setAriaLabels();
+        this.setActiveTab(this.getActiveTab() || this.getAllTabs()[0], false);
+        observer.unobserve(entries[0].target);
+      }
+    });
+    observer.observe(this.host);
+
     focusVisible.observe(this.tabGroup);
 
     // Update aria labels if the DOM changes


### PR DESCRIPTION
`setActiveTab` requires the tabs to be visible since it requests the `clientWidth` of the active tab, but this will be 0 if the element is not yet visible when `componentDidLoad` runs. This commit uses an IntersectionObserver to watch for the element to become visible and then runs the initialisation for the active tabs. The observer is unregistered as soon as it is called since it only needs to be called once.