### PR TITLE
Fixes #162 - Update index.ts component export reference to the new format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from './components';
+export { Components, JSX } from './components';


### PR DESCRIPTION
This was changed from Stencil v1.14.0 