### PR TITLE
Fixes #164 - Set base to same height as menu element for select component

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -59,6 +59,18 @@ To allow multiple options to be selected, use the `multiple` attribute.
   <sl-menu-item value="option-4">Option 4</sl-menu-item>
   <sl-menu-item value="option-5">Option 5</sl-menu-item>
   <sl-menu-item value="option-6">Option 6</sl-menu-item>
+  <sl-menu-divider></sl-menu-divider>
+  <sl-menu-item value="option-7">Option 7</sl-menu-item>
+  <sl-menu-item value="option-8">Option 8</sl-menu-item>
+  <sl-menu-item value="option-9">Option 9</sl-menu-item>
+  <sl-menu-divider></sl-menu-divider>
+  <sl-menu-item value="option-10">Option 10</sl-menu-item>
+  <sl-menu-item value="option-11">Option 11</sl-menu-item>
+  <sl-menu-item value="option-12">Option 12</sl-menu-item>
+  <sl-menu-divider></sl-menu-divider>
+  <sl-menu-item value="option-13">Option 13</sl-menu-item>
+  <sl-menu-item value="option-14">Option 14</sl-menu-item>
+  <sl-menu-item value="option-15">Option 15</sl-menu-item>
 </sl-select>
 ```
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -37,3 +37,7 @@
 .select--open .select__icon sl-icon {
   transform: rotate(-180deg);
 }
+
+sl-menu.select__menu::part(base) {
+  max-height: 50vh;
+}


### PR DESCRIPTION
Fixes #164 
- Set base part to same height as the menu element
- Update the select component documentation to include a scrolling select example