### PR TITLE
fix: Improve accuracy of determining activeElement in Dropdown

### DIFF
--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -220,10 +220,17 @@ export class Dropdown {
     if (event.key === 'Tab') {
       setTimeout(() => {
         // Tabbing outside of the containing element closes the panel
-        if (
-          document.activeElement &&
-          document.activeElement.closest(this.containingElement.tagName.toLowerCase()) !== this.containingElement
-        ) {
+
+        // If the dropdown is used within a shadow DOM, we need to
+        // obtain the activeElement within that shadowRoot, otherwise
+        // `document.activeElement` will only return the name of the
+        // parent shadow DOM element.
+        const activeElement =
+          this.containingElement.getRootNode() instanceof ShadowRoot
+            ? document.activeElement.shadowRoot?.activeElement
+            : document.activeElement;
+
+        if (activeElement?.closest(this.containingElement.tagName.toLowerCase()) !== this.containingElement) {
           this.hide();
           return;
         }


### PR DESCRIPTION
Fixes #223 

If `sl-dropdown` is used within a shadow root, we need to obtain `document.activeElement.shadowRoot?.activeElement` rather than just `document.activeElement` to determine the actively focused element.

Applying this fix to the [minimum reproduction](https://github.com/zolk/shoelace/commit/63e23c77c1b99b2751b880947aa936fef1460157) resolves the issue.

![Screen Recording 2020-09-25 at 18 04 58](https://user-images.githubusercontent.com/3734/94323784-b65f6280-ff5c-11ea-90bf-d772664d24bc.gif)
