### PR TITLE
docs: fix typo

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -85,7 +85,7 @@ export class Input {
   /** A pattern to validate input against. */
   @Prop({ reflect: true }) pattern: string;
 
-  /** Set to true to make the checkbox a required field. */
+  /** Set to true to make the input a required field. */
   @Prop({ reflect: true }) required: boolean;
 
   /** The input's autocaptialize attribute. */


### PR DESCRIPTION
It wasnt immediately obvious where the data within the sl:input properties table of the docs came from.

Initially I tried to find the typo in https://github.com/shoelace-style/shoelace/blob/next/docs/components/input.md

I found the metadata plugin but then got lost where the actual data values come from.
I guess a comment in the metadata plugin to make it obvious where the actual data is coming from would be helpful