### PR TITLE
Add guard for Popover destroy

### DIFF
--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -143,7 +143,7 @@ export class Dropdown {
   disconnectedCallback() {
     this.hide();
     
-    if (this.popper) {
+    if (this.popover) {
       this.popover.destroy();
     }
   }

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -142,7 +142,10 @@ export class Dropdown {
 
   disconnectedCallback() {
     this.hide();
-    this.popover.destroy();
+    
+    if (this.popper) {
+      this.popover.destroy();
+    }
   }
 
   /** Shows the dropdown panel */

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -114,7 +114,7 @@ export class Tooltip {
   }
 
   disconnectedCallback() {
-    if (this.popper) {
+    if (this.popover) {
       this.popover.destroy();
     }
 

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -114,7 +114,9 @@ export class Tooltip {
   }
 
   disconnectedCallback() {
-    this.popover.destroy();
+    if (this.popper) {
+      this.popover.destroy();
+    }
 
     this.host.removeEventListener('blur', this.handleBlur, true);
     this.host.removeEventListener('click', this.handleClick, true);


### PR DESCRIPTION
When using Shoelace with React I am getting an error where the popover is undefined at the point that it is being destroyed.

This PR adds a guard to prevent this error.

Stack trace for the error:
```
disconnectedCallback — p-82050c8e.entry.js:56
H — p-bf36b983.js:277
https://cdn.jsdelivr.net/npm/
disconnectedCallback — p-bf36b983.js:425
removeChild
removeChild
unmountHostComponents
commitDeletion
commitAllHostEffects
callCallback
dispatchEvent
invokeGuardedCallbackDev
```