### PR TITLE
Fix Rails Integration docs: Missing module export statement

### DIFF
--- a/docs/tutorials/integrating-with-rails.md
+++ b/docs/tutorials/integrating-with-rails.md
@@ -69,6 +69,8 @@ environment.plugins.append(
     ]
   })
 )
+
+module.exports = environment
 ```
 
 ### Adding Pack Tags


### PR DESCRIPTION
Thanks for this great library @claviska! 

Tried adding Shoelace to a Rails app w/ the current guide. When starting the Webpack Dev Server, the following error gets thrown:

```
.../RailsApplication/config/webpack/development.js:5
module.exports = environment.toWebpackConfig()
```
Adding `module.exports = environment` as done [here in the example repo](https://github.com/ParamagicDev/rails-shoelace-example/blob/4114da0e14e7276718df5091f28be7a96513144b/config/webpack/environment.js#L20) fixes the issue and allows Webpack to compile.