### PR TITLE
DOCS: Fix asset path for Rails

### DIFF
--- a/docs/tutorials/integrating-with-rails.md
+++ b/docs/tutorials/integrating-with-rails.md
@@ -36,8 +36,13 @@ import { defineCustomElements, setAssetPath } from '@shoelace-style/shoelace'
 
 // ...
 
+const rootUrl = document.currentScript.src.replace(/\/packs.*$/, '')
+
+// Path to the assets folder (should be independent on the current script source path
+// to work correctly in different environments)
+setAssetPath(rootUrl + '/packs/js/')
+
 // This enables all web components for the current page
-setAssetPath(document.currentScript.src)
 defineCustomElements()
 ```
 


### PR DESCRIPTION
The path to assets should be consistent and not depend on the current script source. There are at least two situations when this assumption fails:
- When running `webpacker-dev-server`, the _pack_ URL doesn't contain `/js/` part.
- In test environment, `/packs-test` is used by default.