### PR TITLE
Add border radius to button-group root element

### DIFF
--- a/src/components/button-group/button-group.scss
+++ b/src/components/button-group/button-group.scss
@@ -2,6 +2,7 @@
 
 :host {
   display: inline-block;
+  border-radius: var(--sl-input-border-radius-medium);
 }
 
 .button-group {


### PR DESCRIPTION
Fixes display of box-shadows on button groups. Without this change, adding a box-shadow to a button group will result in a sharp corner eating into the box shadow styles. See screenshots below, taking note of the bottom left-hand corner.

## Before
<img width="233" alt="Screen Shot 2021-01-28 at 3 00 46 PM" src="https://user-images.githubusercontent.com/14965732/106198692-fab47680-6179-11eb-990e-7c76bbfb7cea.png">

## After
<img width="233" alt="Screen Shot 2021-01-28 at 3 00 36 PM" src="https://user-images.githubusercontent.com/14965732/106198698-fdaf6700-6179-11eb-88e4-3300e775b002.png">

One minor hiccup with this code is that the button group does not know what the size of the buttons placed in it will be. By default, `--sl-input-border-radius-small`, `--sl-input-border-radius-medium`, and `--sl-input-border-radius-large` are all [set to the same value](https://github.com/shoelace-style/shoelace/blob/9bea517ae8a8a980b02a0b62e24bbee37b11beb7/src/styles/shoelace.scss#L205-L207) (`--sl-border-radius-medium`). But if the consumer changed those values, it would could cause the border radius of the button group to differ from that of the buttons contained inside it. I'm not sure of a good solution to this, other than reworking the button group to take a size and pass it down to its children, or inspecting the children to get the size. Do you have any thoughts on the matter?