### PR TITLE
Emit sl-error in sl-icon for failing requests

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -105,6 +105,8 @@ export class Icon {
             this.svg = '';
             this.slError.emit({ status: file.status });
           }
+        } else {
+          this.slError.emit({ status: file.status });
         }
       } catch {
         this.slError.emit();


### PR DESCRIPTION
Listening to the `sl-error` event of `sl-icon` is not triggered if the request to the svg fails. Example

```html
<sl-icon id="triangle" name="exclamation-triangle"></sl-icon>
<sl-icon id="missing"  name="missing"></sl-icon>

<script>
  // works fine
  document.getElementById("triangle").addEventListener("sl-load", () => console.log("loaded"))
  // never triggered
  document.getElementById("missing").addEventListener("sl-error", (e) => console.log("error", e))
</script>
```

This PR fixes this by emitting the event if `file.ok` is false.
