### PR TITLE
Make dialog overlay non focusable

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -229,7 +229,7 @@ export class Dialog {
         onKeyDown={this.handleKeyDown}
         onTransitionEnd={this.handleTransitionEnd}
       >
-        <div part="overlay" class="dialog__overlay" onClick={this.handleOverlayClick} />
+        <div part="overlay" class="dialog__overlay" onClick={this.handleOverlayClick} tabIndex={-1} />
 
         <div
           ref={el => (this.panel = el)}


### PR DESCRIPTION
If you click the overlay in the [ignore clicks on the overlay](https://shoelace.style/components/dialog?id=ignoring-clicks-on-the-overlay) demo you can no longer press escape to close the modal since the overlay has been focused.