### PR TITLE
fix css custom prop name in docs

### DIFF
--- a/scripts/make-metadata.cjs
+++ b/scripts/make-metadata.cjs
@@ -160,7 +160,7 @@ components.map(async component => {
     const tags = parsed[0] ? parsed[0].tags : [];
     const cssCustomProperties = tags
       .filter(tag => tag.tag === 'prop')
-      .map(tag => api.cssCustomProperties.push({ name: tag.name, description: tag.description }));
+      .map(tag => api.cssCustomProperties.push({ name: tag.name.slice(0, -1), description: tag.description }));
   }
 
   metadata.components.push(api);

--- a/scripts/make-metadata.cjs
+++ b/scripts/make-metadata.cjs
@@ -160,7 +160,7 @@ components.map(async component => {
     const tags = parsed[0] ? parsed[0].tags : [];
     const cssCustomProperties = tags
       .filter(tag => tag.tag === 'prop')
-      .map(tag => api.cssCustomProperties.push({ name: tag.tag, description: tag.description }));
+      .map(tag => api.cssCustomProperties.push({ name: tag.name, description: tag.description }));
   }
 
   metadata.components.push(api);


### PR DESCRIPTION
Currently, only the string 'prop' shows up at any section in the docs about css custom properties:

![image](https://user-images.githubusercontent.com/5441654/110134644-e9d8cf80-7dcd-11eb-8e5f-7c505055eb0a.png)

This change restores the actual CSS property names again ⬇ ...

![image](https://user-images.githubusercontent.com/5441654/110134558-cf9ef180-7dcd-11eb-968b-332ba1e9d35a.png)

and removes the trailing colons ⬇

![image](https://user-images.githubusercontent.com/5441654/110135261-9450f280-7dce-11eb-9ff1-8a473fec6765.png)

