### PR TITLE
add touch functionality on rating component

### DIFF
--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -60,20 +60,18 @@ export default class SlRating extends Shoemaker {
   }
 
   getValueFromMousePosition(event: MouseEvent) {
-    const containerLeft = this.rating.getBoundingClientRect().left;
-    const containerWidth = this.rating.getBoundingClientRect().width;
-    return clamp(
-      this.roundToPrecision(((event.clientX - containerLeft) / containerWidth) * this.max, this.precision),
-      0,
-      this.max
-    );
+    return this.getValueFromXCoordinate(event.clientX);
   }
 
   getValueFromTouchPosition(event: TouchEvent) {
+    return this.getValueFromXCoordinate(event.touches[0].clientX);
+  }
+
+  private getValueFromXCoordinate(coordinate: number) {
     const containerLeft = this.rating.getBoundingClientRect().left;
     const containerWidth = this.rating.getBoundingClientRect().width;
     return clamp(
-      this.roundToPrecision(((event.touches[0].clientX - containerLeft) / containerWidth) * this.max, this.precision),
+      this.roundToPrecision(((coordinate - containerLeft) / containerWidth) * this.max, this.precision),
       0,
       this.max
     );


### PR DESCRIPTION
This pull request aims to make the rating component work on mobile as it does on desktop and feel more natural.

Currently the rating component only reacts to the click event on mobile.
By adding TouchStart (to imitate mouseEnter), TouchMove (MouseMove) and TouchEnd (MouseLeave), the rating component reacts to touch- as it does to mouse-event and, in my opinion, feels the way it should.

Let me know if this is not intended behavior or my code does not correspond to the project's standards.