### PR TITLE
declare types for component tags

### DIFF
--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -212,3 +212,9 @@ export default class SlAlert extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-alert': SlAlert;
+        }
+    }

--- a/src/components/animation/animation.ts
+++ b/src/components/animation/animation.ts
@@ -202,3 +202,9 @@ export default class SlAnimation extends LitElement {
     return html` <slot @slotchange=${this.handleSlotChange}></slot> `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-animation': SlAnimation;
+        }
+    }

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -65,3 +65,9 @@ export default class SlAvatar extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-avatar': SlAvatar;
+        }
+    }

--- a/src/components/badge/badge.ts
+++ b/src/components/badge/badge.ts
@@ -45,3 +45,9 @@ export default class SlBadge extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-badge': SlBadge;
+        }
+    }

--- a/src/components/button-group/button-group.ts
+++ b/src/components/button-group/button-group.ts
@@ -41,3 +41,9 @@ export default class SlButtonGroup extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-button-group': SlButtonGroup;
+        }
+    }

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -227,3 +227,9 @@ export default class SlButton extends LitElement {
     return isLink ? link : button;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-button': SlButton;
+        }
+    }

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -68,3 +68,9 @@ export default class SlCard extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-card': SlCard;
+        }
+    }

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -183,3 +183,9 @@ export default class SlCheckbox extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-checkbox': SlCheckbox;
+        }
+    }

--- a/src/components/color-picker/color-picker.ts
+++ b/src/components/color-picker/color-picker.ts
@@ -821,3 +821,9 @@ export default class SlColorPicker extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-color-picker': SlColorPicker;
+        }
+    }

--- a/src/components/details/details.ts
+++ b/src/components/details/details.ts
@@ -211,3 +211,9 @@ export default class SlDetails extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-details': SlDetails;
+        }
+    }

--- a/src/components/dialog/dialog.ts
+++ b/src/components/dialog/dialog.ts
@@ -261,3 +261,9 @@ export default class SlDialog extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-dialog': SlDialog;
+        }
+    }

--- a/src/components/drawer/drawer.ts
+++ b/src/components/drawer/drawer.ts
@@ -272,3 +272,9 @@ export default class SlDrawer extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-drawer': SlDrawer;
+        }
+    }

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -407,3 +407,9 @@ export default class SlDropdown extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-dropdown': SlDropdown;
+        }
+    }

--- a/src/components/form/form.ts
+++ b/src/components/form/form.ts
@@ -279,3 +279,9 @@ export default class SlForm extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-form': SlForm;
+        }
+    }

--- a/src/components/format-bytes/format-bytes.ts
+++ b/src/components/format-bytes/format-bytes.ts
@@ -24,3 +24,9 @@ export default class SlFormatBytes extends LitElement {
     });
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-format-bytes': SlFormatBytes;
+        }
+    }

--- a/src/components/format-date/format-date.ts
+++ b/src/components/format-date/format-date.ts
@@ -70,3 +70,9 @@ export default class SlFormatDate extends LitElement {
     }).format(date);
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-format-date': SlFormatDate;
+        }
+    }

--- a/src/components/format-number/format-number.ts
+++ b/src/components/format-number/format-number.ts
@@ -58,3 +58,9 @@ export default class SlFormatNumber extends LitElement {
     }).format(this.value);
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-format-number': SlFormatNumber;
+        }
+    }

--- a/src/components/icon-button/icon-button.ts
+++ b/src/components/icon-button/icon-button.ts
@@ -68,3 +68,9 @@ export default class SlIconButton extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-icon-button': SlIconButton;
+        }
+    }

--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -120,3 +120,9 @@ export default class SlIcon extends LitElement {
     return html` <div part="base" class="icon" role="img" aria-label=${this.getLabel()}>${unsafeSVG(this.svg)}</div>`;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-icon': SlIcon;
+        }
+    }

--- a/src/components/image-comparer/image-comparer.ts
+++ b/src/components/image-comparer/image-comparer.ts
@@ -135,3 +135,9 @@ export default class SlImageComparer extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-image-comparer': SlImageComparer;
+        }
+    }

--- a/src/components/include/include.ts
+++ b/src/components/include/include.ts
@@ -78,3 +78,9 @@ export default class SlInclude extends LitElement {
     return html`<slot></slot>`;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-include': SlInclude;
+        }
+    }

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -376,3 +376,9 @@ export default class SlInput extends LitElement {
     );
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-input': SlInput;
+        }
+    }

--- a/src/components/menu-divider/menu-divider.ts
+++ b/src/components/menu-divider/menu-divider.ts
@@ -18,3 +18,9 @@ export default class SlMenuDivider extends LitElement {
     return html` <div part="base" class="menu-divider" role="separator" aria-hidden="true"></div> `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-menu-divider': SlMenuDivider;
+        }
+    }

--- a/src/components/menu-item/menu-item.ts
+++ b/src/components/menu-item/menu-item.ts
@@ -100,3 +100,9 @@ export default class SlMenuItem extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-menu-item': SlMenuItem;
+        }
+    }

--- a/src/components/menu-label/menu-label.ts
+++ b/src/components/menu-label/menu-label.ts
@@ -24,3 +24,9 @@ export default class SlMenuLabel extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-menu-label': SlMenuLabel;
+        }
+    }

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -124,3 +124,9 @@ export default class SlMenu extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-menu': SlMenu;
+        }
+    }

--- a/src/components/progress-bar/progress-bar.ts
+++ b/src/components/progress-bar/progress-bar.ts
@@ -50,3 +50,9 @@ export default class SlProgressBar extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-progress-bar': SlProgressBar;
+        }
+    }

--- a/src/components/progress-ring/progress-ring.ts
+++ b/src/components/progress-ring/progress-ring.ts
@@ -76,3 +76,9 @@ export default class SlProgressRing extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-progress-ring': SlProgressRing;
+        }
+    }

--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -180,3 +180,9 @@ export default class SlRadio extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-radio': SlRadio;
+        }
+    }

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -210,3 +210,9 @@ export default class SlRange extends LitElement {
     );
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-range': SlRange;
+        }
+    }

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -242,3 +242,9 @@ export default class SlRating extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-rating': SlRating;
+        }
+    }

--- a/src/components/relative-time/relative-time.ts
+++ b/src/components/relative-time/relative-time.ts
@@ -116,3 +116,9 @@ export default class SlRelativeTime extends LitElement {
     return html` <time datetime=${this.isoTime} title=${this.titleTime}>${this.relativeTime}</time> `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-relative-time': SlRelativeTime;
+        }
+    }

--- a/src/components/resize-observer/resize-observer.ts
+++ b/src/components/resize-observer/resize-observer.ts
@@ -45,3 +45,9 @@ export default class SlResizeObserver extends LitElement {
     return html` <slot @slotchange=${this.handleSlotChange}></slot> `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-resize-observer': SlResizeObserver;
+        }
+    }

--- a/src/components/responsive-embed/responsive-embed.ts
+++ b/src/components/responsive-embed/responsive-embed.ts
@@ -37,3 +37,9 @@ export default class SlResponsiveEmbed extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-responsive-embed': SlResponsiveEmbed;
+        }
+    }

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -465,3 +465,9 @@ export default class SlSelect extends LitElement {
     );
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-select': SlSelect;
+        }
+    }

--- a/src/components/skeleton/skeleton.ts
+++ b/src/components/skeleton/skeleton.ts
@@ -34,3 +34,9 @@ export default class SlSkeleton extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-skeleton': SlSkeleton;
+        }
+    }

--- a/src/components/spinner/spinner.ts
+++ b/src/components/spinner/spinner.ts
@@ -16,3 +16,9 @@ export default class SlSpinner extends LitElement {
     return html` <span part="base" class="spinner" aria-busy="true" aria-live="polite"></span> `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-spinner': SlSpinner;
+        }
+    }

--- a/src/components/switch/switch.ts
+++ b/src/components/switch/switch.ts
@@ -156,3 +156,9 @@ export default class SlSwitch extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-switch': SlSwitch;
+        }
+    }

--- a/src/components/tab-group/tab-group.ts
+++ b/src/components/tab-group/tab-group.ts
@@ -360,3 +360,9 @@ export default class SlTabGroup extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-tab-group': SlTabGroup;
+        }
+    }

--- a/src/components/tab-panel/tab-panel.ts
+++ b/src/components/tab-panel/tab-panel.ts
@@ -44,3 +44,9 @@ export default class SlTabPanel extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-tab-panel': SlTabPanel;
+        }
+    }

--- a/src/components/tab/tab.ts
+++ b/src/components/tab/tab.ts
@@ -88,3 +88,9 @@ export default class SlTab extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-tab': SlTab;
+        }
+    }

--- a/src/components/tag/tag.ts
+++ b/src/components/tag/tag.ts
@@ -81,3 +81,9 @@ export default class SlTag extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-tag': SlTag;
+        }
+    }

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -296,3 +296,9 @@ export default class SlTextarea extends LitElement {
     );
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-textarea': SlTextarea;
+        }
+    }

--- a/src/components/tooltip/tooltip.ts
+++ b/src/components/tooltip/tooltip.ts
@@ -262,3 +262,9 @@ export default class SlTooltip extends LitElement {
     `;
   }
 }
+
+    declare global {
+        interface HTMLElementTagNameMap {
+        'sl-tooltip': SlTooltip;
+        }
+    }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -71,5 +71,9 @@
     "removeComments": true,
     "skipLibCheck": true                      /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "exclude": [
+    "docs",
+    "dist"
+  ]
 }


### PR DESCRIPTION
Since changing to lit-element, compiling angular templates in strict mode with shoelace components fails in certain situations. Reason are the missing type declarations. This PR fixes this by adding them for each component.

See https://stackoverflow.com/questions/65148695/lit-element-typescript-project-global-interface-declaration-necessary
