### PR TITLE
Change from ::slotted to ::part for cards

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -30,7 +30,7 @@
   margin: calc(-1 * var(--border-width));
   overflow: hidden;
 
-  ::slotted(img) {
+  ::part(image) {
     display: block;
     width: 100%;
   }


### PR DESCRIPTION
Shoelace uses `part="image"` instead of `slot="image"`

It appears the style never got updated! Obviously the docs are going to have to be updated as well.