### PR TITLE
button: fix stuck hover style on mobile

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -70,11 +70,14 @@
     background-color: var(--sl-color-white);
     border-color: var(--sl-color-gray-300);
     color: var(--sl-color-gray-600);
+    -webkit-tap-highlight-color: var(--sl-color-primary-300);
 
-    &:hover:not(.button--disabled) {
-      background-color: var(--sl-color-primary-50);
-      border-color: var(--sl-color-primary-300);
-      color: var(--sl-color-primary-600);
+    @media (hover: hover) and (pointer: fine) {
+      &:hover:not(.button--disabled) {
+        background-color: var(--sl-color-primary-50);
+        border-color: var(--sl-color-primary-300);
+        color: var(--sl-color-primary-600);
+      }
     }
 
     &:focus:not(.button--disabled) {
@@ -95,11 +98,14 @@
     background-color: var(--sl-color-primary-500);
     border-color: var(--sl-color-primary-500);
     color: var(--sl-color-primary-text);
+    -webkit-tap-highlight-color: var(--sl-color-primary-400);
 
-    &:hover:not(.button--disabled) {
-      background-color: var(--sl-color-primary-400);
-      border-color: var(--sl-color-primary-400);
-      color: var(--sl-color-primary-text);
+    @media (hover: hover) and (pointer: fine) {
+      &:hover:not(.button--disabled) {
+        background-color: var(--sl-color-primary-400);
+        border-color: var(--sl-color-primary-400);
+        color: var(--sl-color-primary-text);
+      }
     }
 
     &:focus:not(.button--disabled) {
@@ -120,11 +126,14 @@
     background-color: var(--sl-color-success-500);
     border-color: var(--sl-color-success-500);
     color: var(--sl-color-success-text);
+    -webkit-tap-highlight-color: var(--sl-color-success-400);
 
-    &:hover:not(.button--disabled) {
-      background-color: var(--sl-color-success-400);
-      border-color: var(--sl-color-success-400);
-      color: var(--sl-color-success-text);
+    @media (hover: hover) and (pointer: fine) {
+      &:hover:not(.button--disabled) {
+        background-color: var(--sl-color-success-400);
+        border-color: var(--sl-color-success-400);
+        color: var(--sl-color-success-text);
+      }
     }
 
     &:focus:not(.button--disabled) {
@@ -145,11 +154,14 @@
     background-color: var(--sl-color-info-500);
     border-color: var(--sl-color-info-500);
     color: var(--sl-color-info-text);
+    -webkit-tap-highlight-color: var(--sl-color-info-400);
 
-    &:hover:not(.button--disabled) {
-      background-color: var(--sl-color-info-400);
-      border-color: var(--sl-color-info-400);
-      color: var(--sl-color-info-text);
+    @media (hover: hover) and (pointer: fine) {
+      &:hover:not(.button--disabled) {
+        background-color: var(--sl-color-info-400);
+        border-color: var(--sl-color-info-400);
+        color: var(--sl-color-info-text);
+      }
     }
 
     &:focus:not(.button--disabled) {
@@ -170,11 +182,14 @@
     background-color: var(--sl-color-warning-500);
     border-color: var(--sl-color-warning-500);
     color: var(--sl-color-warning-text);
+    -webkit-tap-highlight-color: var(--sl-color-warning-400);
 
-    &:hover:not(.button--disabled) {
-      background-color: var(--sl-color-warning-400);
-      border-color: var(--sl-color-warning-400);
-      color: var(--sl-color-warning-text);
+    @media (hover: hover) and (pointer: fine) {
+      &:hover:not(.button--disabled) {
+        background-color: var(--sl-color-warning-400);
+        border-color: var(--sl-color-warning-400);
+        color: var(--sl-color-warning-text);
+      }
     }
 
     &:focus:not(.button--disabled) {
@@ -195,11 +210,14 @@
     background-color: var(--sl-color-danger-500);
     border-color: var(--sl-color-danger-500);
     color: var(--sl-color-danger-text);
+    -webkit-tap-highlight-color: var(--sl-color-danger-400);
 
-    &:hover:not(.button--disabled) {
-      background-color: var(--sl-color-danger-400);
-      border-color: var(--sl-color-danger-400);
-      color: var(--sl-color-danger-text);
+    @media (hover: hover) and (pointer: fine) {
+      &:hover:not(.button--disabled) {
+        background-color: var(--sl-color-danger-400);
+        border-color: var(--sl-color-danger-400);
+        color: var(--sl-color-danger-text);
+      }
     }
 
     &:focus:not(.button--disabled) {


### PR DESCRIPTION
Hi! Shoelace's current `<sl-button>` UX is not ideal on mobile, since the `:hover` style gets stuck once a button is tapped:

<img width="408" alt="Screen Shot 2021-04-15 at 01 09 32" src="https://user-images.githubusercontent.com/1577223/114791717-3e854800-9d87-11eb-8d49-866efbe70dda.png">

Since just disabling the `:hover` class on non-hover-capable devices (e.g. touch screens) would otherwise leave the button completely static when tapped, I've added the non-standard `-webkit-tap-highlight-color` attribute to the various buttons (except for the text button, which I've left unchanged for now). I understand that this is not great since it only works with Webkit, but I'd argue that *some* mobile-optimization is better than none at all. And let's be honest, WebKit is the de-facto standard for mobile browsers (sorry Firefox, I still love you). The `-webkit-tap-highlight-color` is only visible **very** briefly, something in the 200ms range. In this short time, this is how it looks on iOS:

<img width="374" alt="Screen Shot 2021-04-15 at 00 57 09" src="https://user-images.githubusercontent.com/1577223/114792095-fc103b00-9d87-11eb-8da7-347d1d30f165.png">

A more portable fix for the future could be to use the `:active` pseudo-class, however this apparently requires changes to the JS, more specificially adding a `touchstart` event listener (have not tired it due to limited JS skills).