### PR TITLE
#419 - Basic modifications regarding i18n

### DIFF
--- a/docs/components/format-bytes.md
+++ b/docs/components/format-bytes.md
@@ -46,13 +46,13 @@ To get the value in bits, set the `unit` attribute to `bits`.
 
 ### Localization
 
-Use the `locale` attribute to set the number formatting locale.
+Use the `lang` attribute to set the number formatting locale.
 
 ```html preview
-<sl-format-bytes value="12" locale="de"></sl-format-bytes><br>
-<sl-format-bytes value="1200" locale="de"></sl-format-bytes><br>
-<sl-format-bytes value="1200000" locale="de"></sl-format-bytes><br>
-<sl-format-bytes value="1200000000" locale="de"></sl-format-bytes>
+<sl-format-bytes value="12" lang="de"></sl-format-bytes><br>
+<sl-format-bytes value="1200" lang="de"></sl-format-bytes><br>
+<sl-format-bytes value="1200000" lang="de"></sl-format-bytes><br>
+<sl-format-bytes value="1200000000" lang="de"></sl-format-bytes>
 ```
 
 [component-metadata:sl-format-bytes]

--- a/docs/components/format-date.md
+++ b/docs/components/format-date.md
@@ -53,12 +53,12 @@ By default, the browser will determine whether to use 12-hour or 24-hour time. T
 
 ### Localization
 
-Use the `locale` attribute to set the date/time formatting locale.
+Use the `lang` attribute to set the date/time formatting locale.
 
 ```html preview
-English: <sl-format-date locale="en"></sl-format-date><br>
-French: <sl-format-date locale="fr"></sl-format-date><br>
-Russian: <sl-format-date locale="ru"></sl-format-date><br>
+English: <sl-format-date lang="en"></sl-format-date><br>
+French: <sl-format-date lang="fr"></sl-format-date><br>
+Russian: <sl-format-date lang="ru"></sl-format-date><br>
 ```
 
 [component-metadata:sl-format-date]

--- a/docs/components/format-number.md
+++ b/docs/components/format-number.md
@@ -38,24 +38,24 @@ To get the value as a percent, set the `type` attribute to `percent`.
 
 ### Localization
 
-Use the `locale` attribute to set the number formatting locale.
+Use the `lang` attribute to set the number formatting locale.
 
 ```html preview
-English: <sl-format-number value="2000" locale="en" minimum-fraction-digits="2"></sl-format-number><br>
-German: <sl-format-number value="2000" locale="de" minimum-fraction-digits="2"></sl-format-number><br>
-Russian: <sl-format-number value="2000" locale="ru" minimum-fraction-digits="2"></sl-format-number>
+English: <sl-format-number value="2000" lang="en" minimum-fraction-digits="2"></sl-format-number><br>
+German: <sl-format-number value="2000" lang="de" minimum-fraction-digits="2"></sl-format-number><br>
+Russian: <sl-format-number value="2000" lang="ru" minimum-fraction-digits="2"></sl-format-number>
 ```
 
 ### Currency
 
-To format a number as a monetary value, set the `type` attribute to `currency` and set the `currency` attribute to the desired ISO 4217 currency code. You should also specify `locale` to ensure the the number is formatted correctly for the target locale.
+To format a number as a monetary value, set the `type` attribute to `currency` and set the `currency` attribute to the desired ISO 4217 currency code. You should also specify `lang` to ensure the the number is formatted correctly for the target locale.
 
 ```html preview
-<sl-format-number type="currency" currency="USD" value="2000" locale="en-US"></sl-format-number><br>
-<sl-format-number type="currency" currency="GBP" value="2000" locale="en-GB"></sl-format-number><br>
-<sl-format-number type="currency" currency="EUR" value="2000" locale="de"></sl-format-number><br>
-<sl-format-number type="currency" currency="RUB" value="2000" locale="ru"></sl-format-number><br>
-<sl-format-number type="currency" currency="CNY" value="2000" locale="zh-cn"></sl-format-number>
+<sl-format-number type="currency" currency="USD" value="2000" lang="en-US"></sl-format-number><br>
+<sl-format-number type="currency" currency="GBP" value="2000" lang="en-GB"></sl-format-number><br>
+<sl-format-number type="currency" currency="EUR" value="2000" lang="de"></sl-format-number><br>
+<sl-format-number type="currency" currency="RUB" value="2000" lang="ru"></sl-format-number><br>
+<sl-format-number type="currency" currency="CNY" value="2000" lang="zh-cn"></sl-format-number>
 ```
 
 [component-metadata:sl-format-number]

--- a/docs/components/relative-time.md
+++ b/docs/components/relative-time.md
@@ -48,14 +48,14 @@ You can change how the time is displayed using the `format` attribute. Note that
 
 ### Localization
 
-Use the `locale` attribute to set the desired locale.
+Use the `lang` attribute to set the desired locale.
 
 ```html preview
-English: <sl-relative-time date="2020-07-15T09:17:00-04:00" locale="en-US"></sl-relative-time><br>
-Chinese: <sl-relative-time date="2020-07-15T09:17:00-04:00" locale="zh-CN"></sl-relative-time><br>
-German: <sl-relative-time date="2020-07-15T09:17:00-04:00" locale="de"></sl-relative-time><br>
-Greek: <sl-relative-time date="2020-07-15T09:17:00-04:00" locale="el"></sl-relative-time><br>
-Russian: <sl-relative-time date="2020-07-15T09:17:00-04:00" locale="ru"></sl-relative-time>
+English: <sl-relative-time date="2020-07-15T09:17:00-04:00" lang="en-US"></sl-relative-time><br>
+Chinese: <sl-relative-time date="2020-07-15T09:17:00-04:00" lang="zh-CN"></sl-relative-time><br>
+German: <sl-relative-time date="2020-07-15T09:17:00-04:00" lang="de"></sl-relative-time><br>
+Greek: <sl-relative-time date="2020-07-15T09:17:00-04:00" lang="el"></sl-relative-time><br>
+Russian: <sl-relative-time date="2020-07-15T09:17:00-04:00" lang="ru"></sl-relative-time>
 ```
 
 [component-metadata:sl-relative-time]

--- a/src/components/format-bytes/format-bytes.ts
+++ b/src/components/format-bytes/format-bytes.ts
@@ -1,6 +1,7 @@
 import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { formatBytes } from '../../internal/number';
+import { localize } from '../../internal/i18n';
 
 /**
  * @since 2.0
@@ -8,6 +9,8 @@ import { formatBytes } from '../../internal/number';
  */
 @customElement('sl-format-bytes')
 export default class SlFormatBytes extends LitElement {
+  private t = localize(this);
+
   /** The number to format in bytes. */
   @property({ type: Number }) value = 0;
 
@@ -15,12 +18,12 @@ export default class SlFormatBytes extends LitElement {
   @property() unit: 'bytes' | 'bits' = 'bytes';
 
   /** The locale to use when formatting the number. */
-  @property() locale: string;
+  @property() override lang = '';
 
   render() {
     return formatBytes(this.value, {
       unit: this.unit,
-      locale: this.locale
+      formatNumber: value => this.t.formatNumber(value)
     });
   }
 }

--- a/src/components/format-date/format-date.ts
+++ b/src/components/format-date/format-date.ts
@@ -1,5 +1,6 @@
 import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { localize } from '../../internal/i18n';
 
 /**
  * @since 2.0
@@ -7,11 +8,13 @@ import { customElement, property } from 'lit/decorators.js';
  */
 @customElement('sl-format-date')
 export default class SlFormatDate extends LitElement {
+  private t = localize(this);
+
   /** The date/time to format. If not set, the current date and time will be used. */
   @property() date: Date | string = new Date();
 
   /** The locale to use when formatting the date/time. */
-  @property() locale: string;
+  @property() override lang = '';
 
   /** The format for displaying the weekday. */
   @property() weekday: 'narrow' | 'short' | 'long';
@@ -55,7 +58,7 @@ export default class SlFormatDate extends LitElement {
       return;
     }
 
-    return new Intl.DateTimeFormat(this.locale, {
+    return this.t.formatDate(date, {
       weekday: this.weekday,
       era: this.era,
       year: this.year,
@@ -67,7 +70,7 @@ export default class SlFormatDate extends LitElement {
       timeZoneName: this.timeZoneName,
       timeZone: this.timeZone,
       hour12: hour12
-    }).format(date);
+    });
   }
 }
 

--- a/src/components/format-number/format-number.ts
+++ b/src/components/format-number/format-number.ts
@@ -1,5 +1,6 @@
 import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { localize } from '../../internal/i18n';
 
 /**
  * @since 2.0
@@ -7,11 +8,13 @@ import { customElement, property } from 'lit/decorators.js';
  */
 @customElement('sl-format-number')
 export default class SlFormatNumber extends LitElement {
+  private t = localize(this);
+
   /** The number to format. */
   @property({ type: Number }) value = 0;
 
   /** The locale to use when formatting the number. */
-  @property() locale: string;
+  @property() override lang = '';
 
   /** The formatting style to use. */
   @property() type: 'currency' | 'decimal' | 'percent' = 'decimal';
@@ -45,7 +48,7 @@ export default class SlFormatNumber extends LitElement {
       return '';
     }
 
-    return new Intl.NumberFormat(this.locale, {
+    return this.t.formatNumber(this.value, {
       style: this.type,
       currency: this.currency,
       currencyDisplay: this.currencyDisplay,
@@ -55,7 +58,7 @@ export default class SlFormatNumber extends LitElement {
       maximumFractionDigits: this.maximumFractionDigits,
       minimumSignificantDigits: this.minimumSignificantDigits,
       maximumSignificantDigits: this.maximumSignificantDigits
-    }).format(this.value);
+    });
   }
 }
 

--- a/src/components/relative-time/relative-time.ts
+++ b/src/components/relative-time/relative-time.ts
@@ -1,6 +1,7 @@
 import { LitElement, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { watch } from '../../internal/watch';
+import { localize } from '../../internal/i18n';
 
 /**
  * @since 2.0
@@ -9,6 +10,7 @@ import { watch } from '../../internal/watch';
 @customElement('sl-relative-time')
 export default class SlRelativeTime extends LitElement {
   private updateTimeout: any;
+  private t = localize(this);
 
   @state() private isoTime = '';
   @state() private relativeTime = '';
@@ -18,7 +20,7 @@ export default class SlRelativeTime extends LitElement {
   @property() date: Date | string;
 
   /** The locale to use when formatting the number. */
-  @property() locale: string;
+  @property() override lang = '';
 
   /** The formatting style to use. */
   @property() format: 'long' | 'short' | 'narrow' = 'long';
@@ -65,19 +67,19 @@ export default class SlRelativeTime extends LitElement {
     const { unit, value } = availableUnits.find(unit => Math.abs(diff) < unit.max) as any;
 
     this.isoTime = date.toISOString();
-    this.titleTime = new Intl.DateTimeFormat(this.locale, {
+    this.titleTime = this.t.formatDate(date, {
       month: 'long',
       year: 'numeric',
       day: 'numeric',
       hour: 'numeric',
       minute: 'numeric',
       timeZoneName: 'short'
-    }).format(date);
+    });
 
-    this.relativeTime = new Intl.RelativeTimeFormat(this.locale, {
+    this.relativeTime = this.t.formatRelativeTime(Math.round(diff / value), unit, {
       numeric: this.numeric,
       style: this.format
-    }).format(Math.round(diff / value), unit);
+    });
 
     // If sync is enabled, update as time passes
     clearTimeout(this.updateTimeout);

--- a/src/internal/i18n.ts
+++ b/src/internal/i18n.ts
@@ -1,0 +1,65 @@
+// === exports =======================================================
+
+// `localize` is the only allowed access to localization API
+// for Shoelace's core components. It returns a facade that
+// abstracts from the concrete underlying i18n logic.
+// Direct access in components to the `Intl` object or
+// `(Date|Number|Etc).prototype.toLocaleXyz` is forbidden!
+export { localize };
+
+// === types =========================================================
+
+// Maybe in future something like the following could work:
+//
+//  <sl-i18n adapter=${i18nextAdapter}> ... </sl-i18n>
+//    or
+//  <sl-i18n lang="fr-FR" adapter=${xyzAdapter}> ... </sl-i18n>
+//
+type I18nAdapter = {
+  // More arguments may be necessary in the future, for stuff like
+  // auto-refresh on locale change etc.
+  getI18nFacade(elem: HTMLElement): I18nFacade;
+};
+
+// Important: The methods of the i18n facades are NOT pure functions.
+// Their results may change as soon as the current locale
+// changes.
+type I18nFacade = {
+  getLocale(): string;
+  formatDate(value: Date, format?: DateFormat): string;
+  formatNumber(value: number, format?: NumberFormat): string;
+  formatRelativeTime(value: number, unit: RelativeTimeFormatUnit, format?: RelativeTimeFormat): string;
+  // TODO: translate(...): string // or getText, getTerm, tr or whatever
+  // TODO: getFirstDayOfWeek(): number // 0 to 6, 0 means Sunday
+  // etc.
+};
+
+// For conveninece we reuse parts of the Intl types.
+// But only types, no tight coupling with Intl here.
+type DateFormat = Intl.DateTimeFormatOptions;
+type NumberFormat = Intl.NumberFormatOptions;
+type RelativeTimeFormat = Intl.RelativeTimeFormatOptions;
+type RelativeTimeFormatUnit = Intl.RelativeTimeFormatUnit;
+
+// === localize function =============================================
+
+function localize(elem: HTMLElement): I18nFacade {
+  // Currently it's not possible to configure any custom
+  // i18n adapter so we use the default one here.
+  return defaultI18nAdapter.getI18nFacade(elem);
+}
+
+// === default i18n strategy =========================================
+
+const defaultI18nAdapter: I18nAdapter = {
+  getI18nFacade(elem) {
+    const getLocale = () => elem.lang || 'en-US';
+
+    return {
+      getLocale,
+      formatDate: (value, format) => new Intl.DateTimeFormat(getLocale(), format).format(value),
+      formatNumber: (value, format) => new Intl.NumberFormat(getLocale(), format).format(value),
+      formatRelativeTime: (value, unit, format) => new Intl.RelativeTimeFormat(getLocale(), format).format(value, unit)
+    };
+  }
+};

--- a/src/internal/number.ts
+++ b/src/internal/number.ts
@@ -20,7 +20,7 @@ export function formatBytes(bytes: number, options: FormatBytesOptions) {
 
   const i = Math.min(Math.floor(Math.log10(bytes) / 3), units.length - 1);
   const num = Number((bytes / Math.pow(1000, i)).toPrecision(3));
-  const numString = num.toLocaleString(options.locale);
+  const numString = options.formatNumber(num);
   const prefix = isNegative ? '-' : '';
 
   return `${prefix}${numString} ${units[i]}`;
@@ -28,5 +28,5 @@ export function formatBytes(bytes: number, options: FormatBytesOptions) {
 
 interface FormatBytesOptions {
   unit?: 'bytes' | 'bits';
-  locale?: string;
+  formatNumber: (value: number) => string;
 }


### PR DESCRIPTION
@claviska @hanc2006 @prantlf

This pull request contains very basic changes regarding i18n, my (@xdev1 and @mcjazzyfunky are the same human being) interpretation of several proposals in discussion in #419.

The only changes are:

- Attribute/prop `locale` has been renamed to `lang` for all four currently existing localizable Shoelace core components, as proposed by @prantlf and also the way @hanc2006 is handling it in `SlDatePicker`.
  `lang` is preset to `''`. If the component's attribute/prop `lang` is not set then `en-US` will be used as locale.
- No other public API changes except for the above mentioned removal of the `locale` properties.
- Components are not allowed any longer to access `Intl` or `(Date|Number|Etc.).prototype.toLocaleXyz(...)` directly.
  Instead there's a new function `localize(elem: HTMLElement): I18nFacade` that returns a facade which offers all localizable features that are currently needed in Shoelace's core.

Remarks:

- Only minor changes in several files plus one new file `i18n.ts`.
- Support for text translations has NOT been added. This should be handled in a separate Github issue.
- Support for using the `lang` attribute of the `html` element to configure a locale is NOT implemented. This also would be a feature request that should be handled in a separate issue.
- Currently this `localize` function returns an object that implements interface `I18nFacade`.
  This can be changed as soon as translations will be needed (=> SlDatePicker, SlAutocomplete), to better fit the proposal of @hanc2006 regarding this `t` function thing.
  One possibility could be (just for convenience and shorter syntax) that the return type of function `localize` is a type similar to
  
  ```ts
  type Localizer = {
    // overloaded function
    (....) => string
    (...) => string
  } & I18nFacade
  ``` 

Please let me know what you think of these changes and let me know whether we drop this pull request or whether I should continue working on it.
