### PR TITLE
Automate GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+# This workflow will create a GitHub release every time a tag is pushed
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - "v2.*"
+      - "v3.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false


### PR DESCRIPTION
Adds a workflow file to create a GitHub release, when a version tag starting with _v2._ or _v3._ is pushed, as discussed in #482.

The automatically created GitHub release has the following properties:

- the title is the equal to the tag name, e.g. _v2.0.3_
- the release description is a list of all commits since the last tag
- assets are only the release default assets (compressed repo files as _zip_ and _tar.gz_

Example screenshot from a repo of me:

![image](https://user-images.githubusercontent.com/5441654/126067038-8fae2a1d-9eef-4d4c-bac7-88d20d6a051d.png)

This enables all release related GitHub features for Shoelace, like e.g. notifications on release. This workflow uses [action-automatic-releases](https://github.com/marvinpinto/action-automatic-releases).

It's possible to expand this even more by providing a custom release description or custom assets (e.g. an Shoelace build of that tag).