### PR TITLE
Prevents error if sl-input has value undefined

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -295,7 +295,7 @@ export default class SlInput extends LitElement {
             'input--pill': this.pill,
             'input--disabled': this.disabled,
             'input--focused': this.hasFocus,
-            'input--empty': this.value.length === 0,
+            'input--empty': this.value?.length === 0,
             'input--invalid': this.invalid
           })}
         >
@@ -344,7 +344,7 @@ export default class SlInput extends LitElement {
             @blur=${this.handleBlur}
           />
 
-          ${this.clearable && this.value.length > 0
+          ${this.clearable && this.value?.length > 0
             ? html`
                 <button
                   part="clear-button"


### PR DESCRIPTION
The sl-input's value state being `undefined` is very common when using shoelace with frameworks. Instead of erroring out and not showing the input, this should handle it gracefully. Fixes #514 .