### PR TITLE
docs: broken link for design tokens

### DIFF
--- a/docs/getting-started/customizing.md
+++ b/docs/getting-started/customizing.md
@@ -29,7 +29,7 @@ To customize a design token, simply override it in your stylesheet using a `:roo
 }
 ```
 
-Many design tokens are described further along in this documentation. For a complete list, refer to `src/themes/light.styles.ts` in the project's [source code](https://github.com/shoelace-style/shoelace/blob/current/src/themes/base.styles.ts).
+Many design tokens are described further along in this documentation. For a complete list, refer to `src/themes/light.styles.ts` in the project's [source code](https://github.com/shoelace-style/shoelace/blob/current/src/themes/light.styles.ts).
 
 ## Component Parts
 


### PR DESCRIPTION
The docs refer to the old stylesheet