### PR TITLE
test: components/breadcrumb-item

### DIFF
--- a/src/components/breadcrumb-item/breadcrumb-item.test.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.test.ts
@@ -1,13 +1,58 @@
-import { expect, fixture, html, waitUntil } from '@open-wc/testing';
-// import sinon from 'sinon';
+import { expect, fixture, html } from '@open-wc/testing';
 
 import '../../../dist/shoelace.js';
 import type SlBreadcrumbItem from './breadcrumb-item';
 
 describe('<sl-breadcrumb-item>', () => {
+  let el: SlBreadcrumbItem;
+
   it('should render a component', async () => {
     const el = await fixture(html` <sl-breadcrumb-item></sl-breadcrumb-item> `);
 
     expect(el).to.exist;
+  });
+
+  describe('when provided an element in the slot "prefix" to support prefix icons', async () => {
+    before(async () => {
+      el = await fixture<SlBreadcrumbItem>(html`
+        <sl-breadcrumb-item>
+          <span class="prefix-example" slot="prefix">/</span>
+          Home
+        </sl-breadcrumb-item>
+      `);
+    });
+
+    it('should render a component that passes accessibility test', async () => {
+      await expect(el).to.be.accessible();
+    });
+
+    it('should accept as an assigned child in the shadow root', () => {
+      const slot = <HTMLSlotElement>el.shadowRoot.querySelector('slot[name=prefix]');
+      const childNodes = slot.assignedNodes({ flatten: true });
+
+      expect(childNodes.length).to.eq(1);
+    });
+  });
+
+  describe('when provided an element in the slot "suffix" to support suffix icons', async () => {
+    before(async () => {
+      el = await fixture<SlBreadcrumbItem>(html`
+        <sl-breadcrumb-item>
+          <span class="prefix-example" slot="suffix">/</span>
+          Security
+        </sl-breadcrumb-item>
+      `);
+    });
+
+    it('should render a component that passes accessibility test', async () => {
+      await expect(el).to.be.accessible();
+    });
+
+    it('should accept as an assigned child in the shadow root', () => {
+      const slot = <HTMLSlotElement>el.shadowRoot.querySelector('slot[name=suffix]');
+      const childNodes = slot.assignedNodes({ flatten: true });
+
+      expect(childNodes.length).to.eq(1);
+    });
   });
 });

--- a/src/components/breadcrumb-item/breadcrumb-item.test.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.test.ts
@@ -12,6 +12,83 @@ describe('<sl-breadcrumb-item>', () => {
     expect(el).to.exist;
   });
 
+  describe('when provided a href attribute', async () => {
+    describe('and no target', () => {
+      before(async () => {
+        el = await fixture<SlBreadcrumbItem>(html`
+          <sl-breadcrumb-item href="https://jsonplaceholder.typicode.com/">Home</sl-breadcrumb-item>
+        `);
+      });
+
+      it('should render a component that passes accessibility test', async () => {
+        await expect(el).to.be.accessible();
+      });
+
+      it('should render a HTMLAnchorElement, with the supplied href value', () => {
+        const hyperlink: HTMLAnchorElement = el.shadowRoot.querySelector('a');
+        expect(hyperlink).attribute('href', 'https://jsonplaceholder.typicode.com/');
+      });
+    });
+
+    describe('and target, without rel', () => {
+      before(async () => {
+        el = await fixture<SlBreadcrumbItem>(html`
+          <sl-breadcrumb-item href="https://jsonplaceholder.typicode.com/" target="_blank">Help</sl-breadcrumb-item>
+        `);
+      });
+
+      it('should render a component that passes accessibility test', async () => {
+        await expect(el).to.be.accessible();
+      });
+
+      describe('should render a HTMLAnchorElement', () => {
+        let hyperlink: HTMLAnchorElement;
+
+        before(() => {
+          hyperlink = el.shadowRoot.querySelector('a');
+        });
+
+        it('should use the supplied href value, as the href attribute value', () => {
+          expect(hyperlink).attribute('href', 'https://jsonplaceholder.typicode.com/');
+        });
+
+        it('should default rel attribute to "noreferrer noopener"', () => {
+          expect(hyperlink).attribute('rel', 'noreferrer noopener');
+        });
+      });
+    });
+
+    describe('and target, with rel', () => {
+      before(async () => {
+        el = await fixture<SlBreadcrumbItem>(html`
+          <sl-breadcrumb-item href="https://jsonplaceholder.typicode.com/" target="_blank" rel="alternate"
+            >Help</sl-breadcrumb-item
+          >
+        `);
+      });
+
+      it('should render a component that passes accessibility test', async () => {
+        await expect(el).to.be.accessible();
+      });
+
+      describe('should render a HTMLAnchorElement', () => {
+        let hyperlink: HTMLAnchorElement;
+
+        before(() => {
+          hyperlink = el.shadowRoot.querySelector('a');
+        });
+
+        it('should use the supplied href value, as the href attribute value', () => {
+          expect(hyperlink).attribute('href', 'https://jsonplaceholder.typicode.com/');
+        });
+
+        it('should use the supplied rel value, as the rel attribute value', () => {
+          expect(hyperlink).attribute('rel', 'alternate');
+        });
+      });
+    });
+  });
+
   describe('when provided an element in the slot "prefix" to support prefix icons', async () => {
     before(async () => {
       el = await fixture<SlBreadcrumbItem>(html`

--- a/src/components/breadcrumb-item/breadcrumb-item.test.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.test.ts
@@ -6,6 +6,27 @@ import type SlBreadcrumbItem from './breadcrumb-item';
 describe('<sl-breadcrumb-item>', () => {
   let el: SlBreadcrumbItem;
 
+  describe('when not provided a href attribute', async () => {
+    before(async () => {
+      el = await fixture<SlBreadcrumbItem>(html` <sl-breadcrumb-item>Home</sl-breadcrumb-item> `);
+    });
+
+    it('should render a component that passes accessibility test', async () => {
+      await expect(el).to.be.accessible();
+    });
+
+    it('should hide the seperator from screen readers', async () => {
+      const separator: HTMLSpanElement = el.shadowRoot.querySelector('[part="separator"]');
+      expect(separator).attribute('aria-hidden', 'true');
+    });
+
+    it('should render a HTMLButtonElement as the part "label", with a set type "button"', () => {
+      const button: HTMLButtonElement = el.shadowRoot.querySelector('[part="label"]');
+      expect(button).to.exist;
+      expect(button).attribute('type', 'button');
+    });
+  });
+
   describe('when provided a href attribute', async () => {
     describe('and no target', () => {
       before(async () => {

--- a/src/components/breadcrumb-item/breadcrumb-item.test.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.test.ts
@@ -18,8 +18,8 @@ describe('<sl-breadcrumb-item>', () => {
         await expect(el).to.be.accessible();
       });
 
-      it('should render a HTMLAnchorElement, with the supplied href value', () => {
-        const hyperlink: HTMLAnchorElement = el.shadowRoot.querySelector('a');
+      it('should render a HTMLAnchorElement as the part "label", with the supplied href value', () => {
+        const hyperlink: HTMLAnchorElement = el.shadowRoot.querySelector('[part="label"]');
         expect(hyperlink).attribute('href', 'https://jsonplaceholder.typicode.com/');
       });
     });
@@ -35,11 +35,11 @@ describe('<sl-breadcrumb-item>', () => {
         await expect(el).to.be.accessible();
       });
 
-      describe('should render a HTMLAnchorElement', () => {
+      describe('should render a HTMLAnchorElement as the part "label"', () => {
         let hyperlink: HTMLAnchorElement;
 
         before(() => {
-          hyperlink = el.shadowRoot.querySelector('a');
+          hyperlink = el.shadowRoot.querySelector('[part="label"]');
         });
 
         it('should use the supplied href value, as the href attribute value', () => {

--- a/src/components/breadcrumb-item/breadcrumb-item.test.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.test.ts
@@ -6,12 +6,6 @@ import type SlBreadcrumbItem from './breadcrumb-item';
 describe('<sl-breadcrumb-item>', () => {
   let el: SlBreadcrumbItem;
 
-  it('should render a component', async () => {
-    const el = await fixture(html` <sl-breadcrumb-item></sl-breadcrumb-item> `);
-
-    expect(el).to.exist;
-  });
-
   describe('when provided a href attribute', async () => {
     describe('and no target', () => {
       before(async () => {
@@ -109,6 +103,11 @@ describe('<sl-breadcrumb-item>', () => {
 
       expect(childNodes.length).to.eq(1);
     });
+
+    it('should append class "breadcrumb-item--has-prefix" to "base" part', () => {
+      const part = el.shadowRoot?.querySelector('[part="base"]') as HTMLElement;
+      expect(part.classList.value).to.equal('breadcrumb-item breadcrumb-item--has-prefix');
+    });
   });
 
   describe('when provided an element in the slot "suffix" to support suffix icons', async () => {
@@ -130,6 +129,11 @@ describe('<sl-breadcrumb-item>', () => {
       const childNodes = slot.assignedNodes({ flatten: true });
 
       expect(childNodes.length).to.eq(1);
+    });
+
+    it('should append class "breadcrumb-item--has-suffix" to "base" part', () => {
+      const part = el.shadowRoot?.querySelector('[part="base"]') as HTMLElement;
+      expect(part.classList.value).to.equal('breadcrumb-item breadcrumb-item--has-suffix');
     });
   });
 });

--- a/src/components/breadcrumb-item/breadcrumb-item.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.ts
@@ -37,7 +37,7 @@ export default class SlBreadcrumbItem extends LitElement {
   /** Optionally allows the user to determine how the link should talk to the browser.
    * ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types
    */
-  @property() rel: string | undefined;
+  @property() rel: string = 'noreferrer noopener';
 
   handleSlotChange() {
     this.hasPrefix = hasSlot(this, 'prefix');
@@ -46,7 +46,6 @@ export default class SlBreadcrumbItem extends LitElement {
 
   render() {
     const isLink = this.href ? true : false;
-    const rel = this.rel ? this.rel : 'noreferrer noopener';
 
     return html`
       <div
@@ -68,7 +67,7 @@ export default class SlBreadcrumbItem extends LitElement {
                 class="breadcrumb-item__label breadcrumb-item__label--link"
                 href="${this.href}"
                 target="${this.target}"
-                rel=${ifDefined(this.target ? rel : undefined)}
+                rel=${ifDefined(this.target ? this.rel : undefined)}
               >
                 <slot></slot>
               </a>

--- a/src/components/breadcrumb-item/breadcrumb-item.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.ts
@@ -34,6 +34,11 @@ export default class SlBreadcrumbItem extends LitElement {
   /** Tells the browser where to open the link. Only used when `href` is set. */
   @property() target: '_blank' | '_parent' | '_self' | '_top';
 
+  /** Optionally allows the user to determine how the link should talk to the browser.
+   * ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types
+   */
+  @property() rel: string | undefined;
+
   handleSlotChange() {
     this.hasPrefix = hasSlot(this, 'prefix');
     this.hasSuffix = hasSlot(this, 'suffix');
@@ -41,6 +46,7 @@ export default class SlBreadcrumbItem extends LitElement {
 
   render() {
     const isLink = this.href ? true : false;
+    const rel = this.rel ? this.rel : 'noreferrer noopener';
 
     return html`
       <div
@@ -62,7 +68,7 @@ export default class SlBreadcrumbItem extends LitElement {
                 class="breadcrumb-item__label breadcrumb-item__label--link"
                 href="${this.href}"
                 target="${this.target}"
-                rel=${ifDefined(this.target ? 'noreferrer noopener' : undefined)}
+                rel=${ifDefined(this.target ? rel : undefined)}
               >
                 <slot></slot>
               </a>

--- a/src/components/breadcrumb/breadcrumb.test.ts
+++ b/src/components/breadcrumb/breadcrumb.test.ts
@@ -80,14 +80,6 @@ describe('<sl-breadcrumb>', () => {
     it('should render a component that passes accessibility test', async () => {
       await expect(el).to.be.accessible();
     });
-
-    it.skip('should accept "prefix" as an assigned child in the shadow root', () => {
-      // TODO: I suspect this test doesn't work because the slot resides inside the breadcrumb-item not the breadcrumb list
-      const slot = <HTMLSlotElement>el.shadowRoot.querySelector('slot[name=prefix]');
-      const childNodes = slot.assignedNodes({ flatten: true });
-
-      expect(childNodes.length).to.eq(1);
-    });
   });
 
   describe('when provided a standard list of el-breadcrumb-item children and an element in the slot "suffix" to support suffix icons', async () => {
@@ -107,14 +99,6 @@ describe('<sl-breadcrumb>', () => {
 
     it('should render a component that passes accessibility test', async () => {
       await expect(el).to.be.accessible();
-    });
-
-    it.skip('should accept "suffix" as an assigned child in the shadow root', () => {
-      // TODO: I suspect this test doesn't work because the slot resides inside the breadcrumb-item not the breadcrumb list
-      const slot = <HTMLSlotElement>el.shadowRoot.querySelector('slot[name=suffix]');
-      const childNodes = slot.assignedNodes({ flatten: true });
-
-      expect(childNodes.length).to.eq(1);
     });
   });
 });


### PR DESCRIPTION
I made a change here that users should be able to control the "rel" attribute when it's supplied. 

Test suite itself, non-eventful.