### PR TITLE
Update the CSS path in the Integrating with Rails

### DIFF
--- a/docs/tutorials/integrating-with-rails.md
+++ b/docs/tutorials/integrating-with-rails.md
@@ -23,8 +23,11 @@ yarn add @shoelace-style/shoelace copy-webpack-plugin
 The next step is to import Shoelace's default theme (stylesheet) in `app/javascript/stylesheets/application.scss`.
 
 ```css
-@import '~@shoelace-style/shoelace/dist/themes/base';
+@import '~@shoelace-style/shoelace/dist/themes/light';
+@import '~@shoelace-style/shoelace/dist/themes/dark'; // Optional dark theme
 ```
+
+Fore more details about themes, please refer to [Theme Basics](/getting-started/themes?id=theme-basics).
 
 ### Importing Required Scripts
 


### PR DESCRIPTION
The CSS path seems out of date so I just updated it. I also added a line for the dark theme as well as the link to Theme Basics.