### PR TITLE
Bring the sl-divider styles back to the Shadow DOM

### DIFF
--- a/src/components/divider/divider.styles.ts
+++ b/src/components/divider/divider.styles.ts
@@ -10,13 +10,17 @@ export default css`
     --spacing: var(--sl-spacing-medium);
   }
 
-  :host(:not([vertical])) {
+  :host(:not([vertical])) .menu-divider {
     display: block;
     border-top: solid var(--width) var(--color);
     margin: var(--spacing) 0;
   }
 
   :host([vertical]) {
+    height: 100%;
+  }
+
+  :host([vertical]) .menu-divider {
     display: inline-block;
     height: 100%;
     border-left: solid var(--width) var(--color);

--- a/src/components/divider/divider.ts
+++ b/src/components/divider/divider.ts
@@ -30,7 +30,7 @@ export default class SlDivider extends LitElement {
   }
 
   render() {
-    return html``;
+    return html` <div part="base" class="menu-divider"></div> `;
   }
 }
 


### PR DESCRIPTION
As part of the rename from `<sl-menu-divider>` to `<sl-divider>` in 1b5dca52e37fb4a0fc4f92fb65a8c05675b4a6e9 (which I thought was great!), it seems like the border styles have been moved out of the Shadow DOM.

Unfortunately, one of the projects I'm working on has some old CSS with `*` and border styles, which has affected the styles of the `<sl-divider>` component. So I was wondering if it's possible to move it back to the Shadow DOM. Let me know what you think!