### PR TITLE
detect basepath if src contains query string

### DIFF
--- a/src/utilities/base-path.ts
+++ b/src/utilities/base-path.ts
@@ -32,7 +32,7 @@ if (configScript) {
   // Use the data-shoelace attribute
   setBasePath(configScript.getAttribute('data-shoelace')!);
 } else {
-  const fallbackScript = scripts.find(s => /shoelace(\.min)?\.js$/.test(s.src));
+  const fallbackScript = scripts.find(s => /shoelace(\.min)?\.js($|\?)/.test(s.src));
   let path = '';
 
   if (fallbackScript) {


### PR DESCRIPTION
atm shoelace can not detect the correct base-path if the script src contains a query string.
In our case we wanna add a cache buster to make sure, that at any time the newest version is loaded by the client.

e.g. `/js/shoelace.js?v=2.0.0-beta.60`.

I created some test cases at https://regexr.com/696o0, so that we don't break the existing detection.