### PR TITLE
Fix vscode custom data tag name

### DIFF
--- a/scripts/make-vscode-data.js
+++ b/scripts/make-vscode-data.js
@@ -18,7 +18,7 @@ const components = getAllComponents(metadata);
 const vscode = { tags: [] };
 
 components.map(component => {
-  const name = component.tag;
+  const name = component.tagName;
   const attributes = component.attributes?.map(attr => {
     const type = attr.type?.text;
     let values = [];


### PR DESCRIPTION
I also wanted to add url and description but no data wasn't available from `custom-elements.json`, I thought about useing `docs/components/{component}.md` before `## Examples` but that's unpredictable and probably a hell to maintain