### PR TITLE
#592 introduce some shared behavior

### DIFF
--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -3,7 +3,7 @@ export function getAllComponents(metadata) {
 
   metadata.modules.map(module => {
     module.declarations?.map(declaration => {
-      if (declaration.customElement) {
+      if (declaration.customElement && declaration.tagName) {
         const component = declaration;
         const modulePath = module.path;
 

--- a/src/components/check-control/check-control.ts
+++ b/src/components/check-control/check-control.ts
@@ -20,7 +20,9 @@ import { watch } from '../../internal/watch';
 
 export class SlCheckControl extends LitElement {
 
-  @state() private hasFocus = false;
+  @query('input[type="checkbox"]') input: HTMLInputElement;
+
+  @state() protected hasFocus = false;
 
   /** The check control's name attribute. */
   @property() name: string;
@@ -68,6 +70,11 @@ export class SlCheckControl extends LitElement {
   setCustomValidity(message: string) {
     this.input.setCustomValidity(message);
     this.invalid = !this.input.checkValidity();
+  }
+
+  handleFocus() {
+    this.hasFocus = true;
+    emit(this, 'sl-focus');
   }
 
   handleBlur() {

--- a/src/components/check-control/check-control.ts
+++ b/src/components/check-control/check-control.ts
@@ -7,15 +7,9 @@ import { watch } from '../../internal/watch';
  * @since 2.0
  * @status draft
  *
- * @slot - The check control's label.
- *
  * @event sl-blur - Emitted when the control loses focus.
  * @event sl-change - Emitted when the control's checked state changes.
  * @event sl-focus - Emitted when the control gains focus.
- *
- * @csspart base - The component's base wrapper.
- * @csspart control - The check control.
- * @csspart label - The check control label.
  */
 
 export class SlCheckControl extends LitElement {
@@ -44,6 +38,11 @@ export class SlCheckControl extends LitElement {
 
   firstUpdated() {
     this.invalid = !this.input.checkValidity();
+  }
+
+  handleClick() {
+    this.checked = !this.checked;
+    emit(this, 'sl-change');
   }
 
   /** Simulates a click on the check control. */

--- a/src/components/check-control/check-control.ts
+++ b/src/components/check-control/check-control.ts
@@ -1,5 +1,5 @@
 import { LitElement } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { property, query, state } from 'lit/decorators.js';
 import { emit } from '../../internal/event';
 import { watch } from '../../internal/watch';
 
@@ -7,38 +7,35 @@ import { watch } from '../../internal/watch';
  * @since 2.0
  * @status draft
  *
- * @slot - The checkcontrol's label.
+ * @slot - The check control's label.
  *
  * @event sl-blur - Emitted when the control loses focus.
  * @event sl-change - Emitted when the control's checked state changes.
  * @event sl-focus - Emitted when the control gains focus.
  *
  * @csspart base - The component's base wrapper.
- * @csspart control - The checkbox control.
- * @csspart label - The checkbox label.
+ * @csspart control - The check control.
+ * @csspart label - The check control label.
  */
 
 export class SlCheckControl extends LitElement {
 
   @state() private hasFocus = false;
 
-  /** The checkbox's name attribute. */
+  /** The check control's name attribute. */
   @property() name: string;
 
-  /** The checkbox's value attribute. */
+  /** The check control's value attribute. */
   @property() value: string;
 
-  /** Disables the checkbox. */
+  /** Disables the check control. */
   @property({ type: Boolean, reflect: true }) disabled = false;
 
-  /** Makes the checkbox a required field. */
+  /** Makes the check control a required field. */
   @property({ type: Boolean, reflect: true }) required = false;
 
-  /** Draws the checkbox in a checked state. */
+  /** Draws the check control in a checked state. */
   @property({ type: Boolean, reflect: true }) checked = false;
-
-  /** Draws the checkbox in an indeterminate state. */
-  @property({ type: Boolean, reflect: true }) indeterminate = false;
 
   /** This will be true when the control is in an invalid state. Validity is determined by the `required` prop. */
   @property({ type: Boolean, reflect: true }) invalid = false;
@@ -47,17 +44,17 @@ export class SlCheckControl extends LitElement {
     this.invalid = !this.input.checkValidity();
   }
 
-  /** Simulates a click on the checkbox. */
+  /** Simulates a click on the check control. */
   click() {
     this.input.click();
   }
 
-  /** Sets focus on the checkbox. */
+  /** Sets focus on the check control. */
   focus(options?: FocusOptions) {
     this.input.focus(options);
   }
 
-  /** Removes focus from the checkbox. */
+  /** Removes focus from the check control. */
   blur() {
     this.input.blur();
   }

--- a/src/components/check-control/check-control.ts
+++ b/src/components/check-control/check-control.ts
@@ -1,0 +1,89 @@
+import { LitElement } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { emit } from '../../internal/event';
+import { watch } from '../../internal/watch';
+
+/**
+ * @since 2.0
+ * @status draft
+ *
+ * @slot - The checkcontrol's label.
+ *
+ * @event sl-blur - Emitted when the control loses focus.
+ * @event sl-change - Emitted when the control's checked state changes.
+ * @event sl-focus - Emitted when the control gains focus.
+ *
+ * @csspart base - The component's base wrapper.
+ * @csspart control - The checkbox control.
+ * @csspart label - The checkbox label.
+ */
+
+export class SlCheckControl extends LitElement {
+
+  @state() private hasFocus = false;
+
+  /** The checkbox's name attribute. */
+  @property() name: string;
+
+  /** The checkbox's value attribute. */
+  @property() value: string;
+
+  /** Disables the checkbox. */
+  @property({ type: Boolean, reflect: true }) disabled = false;
+
+  /** Makes the checkbox a required field. */
+  @property({ type: Boolean, reflect: true }) required = false;
+
+  /** Draws the checkbox in a checked state. */
+  @property({ type: Boolean, reflect: true }) checked = false;
+
+  /** Draws the checkbox in an indeterminate state. */
+  @property({ type: Boolean, reflect: true }) indeterminate = false;
+
+  /** This will be true when the control is in an invalid state. Validity is determined by the `required` prop. */
+  @property({ type: Boolean, reflect: true }) invalid = false;
+
+  firstUpdated() {
+    this.invalid = !this.input.checkValidity();
+  }
+
+  /** Simulates a click on the checkbox. */
+  click() {
+    this.input.click();
+  }
+
+  /** Sets focus on the checkbox. */
+  focus(options?: FocusOptions) {
+    this.input.focus(options);
+  }
+
+  /** Removes focus from the checkbox. */
+  blur() {
+    this.input.blur();
+  }
+
+  /** Checks for validity and shows the browser's validation message if the control is invalid. */
+  reportValidity() {
+    return this.input.reportValidity();
+  }
+
+  /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */
+  setCustomValidity(message: string) {
+    this.input.setCustomValidity(message);
+    this.invalid = !this.input.checkValidity();
+  }
+
+  handleBlur() {
+    this.hasFocus = false;
+    emit(this, 'sl-blur');
+  }
+
+  @watch('disabled')
+  handleDisabledChange() {
+    // Disabled form controls are always valid, so we need to recheck validity when the state changes
+    if (this.input) {
+      this.input.disabled = this.disabled;
+      this.invalid = !this.input.checkValidity();
+    }
+  }
+}

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -1,6 +1,6 @@
 import { SlCheckControl } from '../check-control/check-control.js';
 import { html } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
@@ -21,12 +21,8 @@ let id = 0;
 export default class SlCheckbox extends SlCheckControl {
   static styles = styles;
 
-  @query('input[type="checkbox"]') input: HTMLInputElement;
-
   private inputId = `checkbox-${++id}`;
   private labelId = `checkbox-label-${id}`;
-
-  @state() private hasFocus = false;
 
   /** Draws the checkbox in an indeterminate state. */
   @property({ type: Boolean, reflect: true }) indeterminate = false;

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -1,6 +1,6 @@
 import { SlCheckControl } from '../check-control/check-control.js';
 import { html } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
@@ -27,6 +27,9 @@ export default class SlCheckbox extends SlCheckControl {
   private labelId = `checkbox-label-${id}`;
 
   @state() private hasFocus = false;
+
+  /** Draws the checkbox in an indeterminate state. */
+  @property({ type: Boolean, reflect: true }) indeterminate = false;
 
   handleClick() {
     this.checked = !this.checked;

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -4,7 +4,6 @@ import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
-import { emit } from '../../internal/event';
 import { watch } from '../../internal/watch';
 import styles from './checkbox.styles';
 
@@ -14,8 +13,13 @@ let id = 0;
  * @since 2.0
  * @status draft
  *
+ * @slot - The checkbox's label.
+ *
+ * @csspart base - The component's base wrapper.
+ * @csspart control - The checkbox control.
  * @csspart checked-icon - The container the wraps the checked icon.
  * @csspart indeterminate-icon - The container that wraps the indeterminate icon.
+ * @csspart label - The checkbox label.
  */
 @customElement('sl-checkbox')
 export default class SlCheckbox extends SlCheckControl {
@@ -28,9 +32,8 @@ export default class SlCheckbox extends SlCheckControl {
   @property({ type: Boolean, reflect: true }) indeterminate = false;
 
   handleClick() {
-    this.checked = !this.checked;
     this.indeterminate = false;
-    emit(this, 'sl-change');
+    super.handleClick();
   }
 
   @watch('checked', { waitUntilFirstUpdate: true })

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -1,5 +1,6 @@
-import { LitElement, html } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { SlCheckControl } from '../check-control/check-control.js';
+import { html } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
@@ -11,22 +12,13 @@ let id = 0;
 
 /**
  * @since 2.0
- * @status stable
+ * @status draft
  *
- * @slot - The checkbox's label.
- *
- * @event sl-blur - Emitted when the control loses focus.
- * @event sl-change - Emitted when the control's checked state changes.
- * @event sl-focus - Emitted when the control gains focus.
- *
- * @csspart base - The component's base wrapper.
- * @csspart control - The checkbox control.
  * @csspart checked-icon - The container the wraps the checked icon.
  * @csspart indeterminate-icon - The container that wraps the indeterminate icon.
- * @csspart label - The checkbox label.
  */
 @customElement('sl-checkbox')
-export default class SlCheckbox extends LitElement {
+export default class SlCheckbox extends SlCheckControl {
   static styles = styles;
 
   @query('input[type="checkbox"]') input: HTMLInputElement;
@@ -36,80 +28,10 @@ export default class SlCheckbox extends LitElement {
 
   @state() private hasFocus = false;
 
-  /** The checkbox's name attribute. */
-  @property() name: string;
-
-  /** The checkbox's value attribute. */
-  @property() value: string;
-
-  /** Disables the checkbox. */
-  @property({ type: Boolean, reflect: true }) disabled = false;
-
-  /** Makes the checkbox a required field. */
-  @property({ type: Boolean, reflect: true }) required = false;
-
-  /** Draws the checkbox in a checked state. */
-  @property({ type: Boolean, reflect: true }) checked = false;
-
-  /** Draws the checkbox in an indeterminate state. */
-  @property({ type: Boolean, reflect: true }) indeterminate = false;
-
-  /** This will be true when the control is in an invalid state. Validity is determined by the `required` prop. */
-  @property({ type: Boolean, reflect: true }) invalid = false;
-
-  firstUpdated() {
-    this.invalid = !this.input.checkValidity();
-  }
-
-  /** Simulates a click on the checkbox. */
-  click() {
-    this.input.click();
-  }
-
-  /** Sets focus on the checkbox. */
-  focus(options?: FocusOptions) {
-    this.input.focus(options);
-  }
-
-  /** Removes focus from the checkbox. */
-  blur() {
-    this.input.blur();
-  }
-
-  /** Checks for validity and shows the browser's validation message if the control is invalid. */
-  reportValidity() {
-    return this.input.reportValidity();
-  }
-
-  /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */
-  setCustomValidity(message: string) {
-    this.input.setCustomValidity(message);
-    this.invalid = !this.input.checkValidity();
-  }
-
   handleClick() {
     this.checked = !this.checked;
     this.indeterminate = false;
     emit(this, 'sl-change');
-  }
-
-  handleBlur() {
-    this.hasFocus = false;
-    emit(this, 'sl-blur');
-  }
-
-  @watch('disabled')
-  handleDisabledChange() {
-    // Disabled form controls are always valid, so we need to recheck validity when the state changes
-    if (this.input) {
-      this.input.disabled = this.disabled;
-      this.invalid = !this.input.checkValidity();
-    }
-  }
-
-  handleFocus() {
-    this.hasFocus = true;
-    emit(this, 'sl-focus');
   }
 
   @watch('checked', { waitUntilFirstUpdate: true })

--- a/src/components/switch/switch.ts
+++ b/src/components/switch/switch.ts
@@ -1,5 +1,6 @@
-import { LitElement, html } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { SlCheckControl } from '../check-control/check-control.js';
+import { html } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
@@ -11,25 +12,12 @@ let id = 0;
 
 /**
  * @since 2.0
- * @status stable
+ * @status draft
  *
- * @slot - The switch's label.
- *
- * @event sl-blur - Emitted when the control loses focus.
- * @event sl-change - Emitted when the control's checked state changes.
- * @event sl-focus - Emitted when the control gains focus.
- *
- * @csspart base - The component's base wrapper.
- * @csspart control - The switch control.
  * @csspart thumb - The switch position indicator.
- * @csspart label - The switch label.
- *
- * @cssproperty --width - The width of the switch.
- * @cssproperty --height - The height of the switch.
- * @cssproperty --thumb-size - The size of the thumb.
  */
 @customElement('sl-switch')
-export default class SlSwitch extends LitElement {
+export default class SlSwitch extends SlCheckControl {
   static styles = styles;
 
   @query('input[type="checkbox"]') input: HTMLInputElement;
@@ -38,59 +26,6 @@ export default class SlSwitch extends LitElement {
   private labelId = `switch-label-${id}`;
 
   @state() private hasFocus = false;
-
-  /** The switch's name attribute. */
-  @property() name: string;
-
-  /** The switch's value attribute. */
-  @property() value: string;
-
-  /** Disables the switch. */
-  @property({ type: Boolean, reflect: true }) disabled = false;
-
-  /** Makes the switch a required field. */
-  @property({ type: Boolean, reflect: true }) required = false;
-
-  /** Draws the switch in a checked state. */
-  @property({ type: Boolean, reflect: true }) checked = false;
-
-  /** This will be true when the control is in an invalid state. Validity is determined by the `required` prop. */
-  @property({ type: Boolean, reflect: true }) invalid = false;
-
-  firstUpdated() {
-    this.invalid = !this.input.checkValidity();
-  }
-
-  /** Simulates a click on the switch. */
-  click() {
-    this.input.click();
-  }
-
-  /** Sets focus on the switch. */
-  focus(options?: FocusOptions) {
-    this.input.focus(options);
-  }
-
-  /** Removes focus from the switch. */
-  blur() {
-    this.input.blur();
-  }
-
-  /** Checks for validity and shows the browser's validation message if the control is invalid. */
-  reportValidity() {
-    return this.input.reportValidity();
-  }
-
-  /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */
-  setCustomValidity(message: string) {
-    this.input.setCustomValidity(message);
-    this.invalid = !this.input.checkValidity();
-  }
-
-  handleBlur() {
-    this.hasFocus = false;
-    emit(this, 'sl-blur');
-  }
 
   @watch('checked')
   handleCheckedChange() {
@@ -103,20 +38,6 @@ export default class SlSwitch extends LitElement {
   handleClick() {
     this.checked = !this.checked;
     emit(this, 'sl-change');
-  }
-
-  @watch('disabled')
-  handleDisabledChange() {
-    // Disabled form controls are always valid, so we need to recheck validity when the state changes
-    if (this.input) {
-      this.input.disabled = this.disabled;
-      this.invalid = !this.input.checkValidity();
-    }
-  }
-
-  handleFocus() {
-    this.hasFocus = true;
-    emit(this, 'sl-focus');
   }
 
   handleKeyDown(event: KeyboardEvent) {

--- a/src/components/switch/switch.ts
+++ b/src/components/switch/switch.ts
@@ -14,7 +14,12 @@ let id = 0;
  * @since 2.0
  * @status draft
  *
+ * @slot - The switch's label.
+ *
+ * @csspart base - The component's base wrapper.
+ * @csspart control - The switch control.
  * @csspart thumb - The switch position indicator.
+ * @csspart label - The switch label.
  */
 @customElement('sl-switch')
 export default class SlSwitch extends SlCheckControl {
@@ -29,11 +34,6 @@ export default class SlSwitch extends SlCheckControl {
       this.input.checked = this.checked;
       this.invalid = !this.input.checkValidity();
     }
-  }
-
-  handleClick() {
-    this.checked = !this.checked;
-    emit(this, 'sl-change');
   }
 
   handleKeyDown(event: KeyboardEvent) {

--- a/src/components/switch/switch.ts
+++ b/src/components/switch/switch.ts
@@ -1,6 +1,6 @@
 import { SlCheckControl } from '../check-control/check-control.js';
 import { html } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
@@ -20,12 +20,8 @@ let id = 0;
 export default class SlSwitch extends SlCheckControl {
   static styles = styles;
 
-  @query('input[type="checkbox"]') input: HTMLInputElement;
-
   private switchId = `switch-${++id}`;
   private labelId = `switch-label-${id}`;
-
-  @state() private hasFocus = false;
 
   @watch('checked')
   handleCheckedChange() {


### PR DESCRIPTION
@claviska,

See #592.

A first attempt at creating a base class for both SlCheckbox and SlSwitch in which the shared behavior is put. Meaning for example that the `checked` and `disabled` properties and the `focus`/`blur` behavior are in SlCheckControl. But the `indeterminate` property and the `click` behavior are specific for SlCheckbox and should not be part of SlSwitch.

All tests are green. I haven't added any new tests though.

~~I also haven't updated the doc generation. Some things like the 'shared' cssparts are missing (no inheritance applied). Needs some love.~~

Does this approach seem viable? I'm okay with trying to extract more shared behavior like this. ~~I would like some help with the documentation.~~ Let me know your thoughts on this.

edit: The docs are generated just fine. I had moved `csspart` declarations to the superclass, but that was wrong. The superclass only has behavior and no visual definition (html template). So it is not logical to define the `csspart`s in the superclass. The fact that SlCheckbox and SlSwitch partially share the same part names is just 'a coincidence' from the shared behavior perspective.

Cheers,
Erik
