### PR TITLE
Added check for PopperInstance before destroying it

### DIFF
--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -131,7 +131,9 @@ export default class SlDropdown extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.hide();
-    this.popover.destroy();
+    if(this.popover) {
+      this.popover.destroy();
+    }
   }
 
   focusOnTrigger() {


### PR DESCRIPTION
I got this error:

<img width="1179" alt="Screenshot 2021-11-29 at 14 52 07" src="https://user-images.githubusercontent.com/48158184/143879965-38c2f986-54cd-4013-b159-4add3c78d6fc.png">

Saw that it was connected to this piece of code:

<img width="846" alt="Screenshot 2021-11-29 at 14 52 33" src="https://user-images.githubusercontent.com/48158184/143880035-c170f7ec-b90b-4a0c-ab62-eb4b812e03af.png">

And if i understand this correctly, then it is valid that `this.popover` can be undefined when calling `disconnectedCallback`, because it is asynchronously created.

<img width="607" alt="Screenshot 2021-11-29 at 14 56 44" src="https://user-images.githubusercontent.com/48158184/143880744-111ebe68-32ff-49bd-8e17-9735c697c978.png">

I therefore added this check in the `disconnectedCallback` method in the dropdown.ts file. 

![Screenshot 2021-11-29 at 14 55 35](https://user-images.githubusercontent.com/48158184/143880542-576710f0-67a6-48b3-a6c7-6b986ae801a5.png)


