### PR TITLE
Add Japanese translation

### DIFF
--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -3,7 +3,7 @@ import type { Translation } from '../utilities/localize';
 
 const translation: Translation = {
   $code: 'ja',
-  $name: 'Japanese',
+  $name: '日本語',
   $dir: 'ltr',
 
   close: '閉じる',

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -1,0 +1,20 @@
+import { registerTranslation } from '../utilities/localize';
+import type { Translation } from '../utilities/localize';
+
+const translation: Translation = {
+  $code: 'ja',
+  $name: 'Japanese',
+  $dir: 'ltr',
+
+  close: '閉じる',
+  copy: 'コピー',
+  progress: '進行',
+  scroll_to_end: '最後にスクロールする',
+  scroll_to_start: '最初にスクロールする',
+  select_a_color_from_the_screen: '画面から色を選択してください',
+  toggle_color_format: '色のフォーマットを切り替える'
+};
+
+registerTranslation(translation);
+
+export default translation;


### PR DESCRIPTION
This adds Japanese translations for the existing texts

Just two things I want to check.

1. Progress is used as in "Progress x%" or as in "x is in progress"
2. Would you mind if the meaning for the scroll texts was closer to "move to the start/end"? If you don't, I can update the PR to reflect that, it would sound more natural in Japanese in my opinion