### PR TITLE
Added sl-kbd class for consistent styling of <kbd> elements

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -82,6 +82,7 @@
   - [Border Radius](/tokens/border-radius)
   - [Transition](/tokens/transition)
   - [Z-index](/tokens/z-index)
+  - [KBD](/tokens/kbd)
 
 - Tutorials
   - [Integrating with Laravel](/tutorials/integrating-with-laravel)

--- a/docs/tokens/kbd.md
+++ b/docs/tokens/kbd.md
@@ -1,0 +1,7 @@
+# KBD
+
+The KBD CSS class helps to provide a consistent style for `<kbd>` elements within your app.
+
+| Class      | Usage                          | Example                      |
+| ---------- | ------------------------------ | ---------------------------- |
+| `.sl-kbd`  | `<kbd class="sl-kbd">\\</kbd>` | <kbd class="sl-kbd">\\</kbd> |

--- a/src/styles/utility.styles.ts
+++ b/src/styles/utility.styles.ts
@@ -20,4 +20,14 @@ export default css`
     --box-shadow: var(--sl-shadow-large);
     margin: var(--sl-spacing-medium);
   }
+
+  .sl-kbd {
+    font-family: var(--sl-font-mono);
+    font-size: 87.5%;
+    background-color: var(--sl-color-neutral-50);
+    border-radius: var(--sl-border-radius-small);
+    border: solid 1px var(--sl-color-neutral-200);
+    box-shadow: inset 0 1px 0 var(--sl-color-neutral-0);
+    padding: 2px 5px;
+  }
 `;


### PR DESCRIPTION
[The Docs](https://github.com/shoelace-style/shoelace/blob/75a0460974313d8bfd45f8c2629415e24c8a17da/docs/assets/styles/docs.css#L297) have a great style for `<kbd>` elements, but it's not a class available to the entire shoelace library.  So this PR adds a `.sl-kbd` CSS class to use across shoelace to get the same styling anywhere shoelace is being used.

Usage:

`<kbd class="sl-kbd">\\</kbd>`

Not sure if I went about adding the documentation in the right place or correctly so feel free to tear apart.