### PR TITLE
dev: reuse existing browser tab for dev server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "lint-staged": "^12.1.5",
         "lunr": "^2.3.9",
         "npm-check-updates": "^12.1.0",
+        "open": "^8.4.0",
         "pascal-case": "^3.1.2",
         "plop": "^3.0.5",
         "prettier": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "lint-staged": "^12.1.5",
     "lunr": "^2.3.9",
     "npm-check-updates": "^12.1.0",
+    "open": "^8.4.0",
     "pascal-case": "^3.1.2",
     "plop": "^3.0.5",
     "prettier": "^2.5.1",


### PR DESCRIPTION
fixes #648

Automatically reuse existing browser tabs when starting a new instance of the dev server. Only open a new tab if an existing connection doesn't connect within 2 seconds. (retry time is 500ms)