### PR TITLE
Adding Gitpod setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,12 +2,6 @@ tasks:
   - init: npm install && npm run build
     command: npm run start
 
-vscode:
-  extensions:
-    - dbaeumer.vscode-eslint
-    - esbenp.prettier-vscode
-    - streetsidesoftware.code-spell-checker
-
 ports:
   - port: 3001
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,34 @@
+tasks:
+  - init: npm install && npm run build
+    command: npm run start
+
+vscode:
+  extensions:
+    - dbaeumer.vscode-eslint
+    - esbenp.prettier-vscode
+    - streetsidesoftware.code-spell-checker
+
+ports:
+  - port: 3001
+    onOpen: ignore
+  - port: 4000
+    onOpen: open-preview
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@ tasks:
 ports:
   - port: 3001
     onOpen: ignore
-  - port: 4000
+  - port: 4000-4999
     onOpen: open-preview
 
 github:

--- a/docs/resources/contributing.md
+++ b/docs/resources/contributing.md
@@ -74,10 +74,7 @@ The author reserves the right to reject any PR that's outside the scope of the p
 
 ## Developing
 
-You can either use Gitpod for a dev environement in the cloud (no local setup is needed, everything is done through your browser)
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/shoelace-style/shoelace)
-
-Or you can set up a local dev environment, [fork the repo](https://github.com/shoelace-style/shoelace/fork) on GitHub, clone it locally, and install its dependencies.
+To set up a local dev environment, [fork the repo](https://github.com/shoelace-style/shoelace/fork) on GitHub, clone it locally, and install its dependencies.
 
 ```bash
 git clone https://github.com/YOUR_GITHUB_USERNAME/shoelace
@@ -92,6 +89,9 @@ npm run start
 ```
 
 After the initial build, a browser will open automatically to a local version of the docs. The documentation is powered by Docsify, which uses raw markdown files to generate pages on the fly.
+
+Alternatively, you can use Gitpod for a dev environment in the cloud (no local setup is needed, everything is done through your browser)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/shoelace-style/shoelace)
 
 ### Creating New Components
 

--- a/docs/resources/contributing.md
+++ b/docs/resources/contributing.md
@@ -74,7 +74,10 @@ The author reserves the right to reject any PR that's outside the scope of the p
 
 ## Developing
 
-To set up a local dev environment, [fork the repo](https://github.com/shoelace-style/shoelace/fork) on GitHub, clone it locally, and install its dependencies.
+You can either use Gitpod for a dev environement in the cloud (no local setup is needed, everything is done through your browser)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/shoelace-style/shoelace)
+
+Or you can set up a local dev environment, [fork the repo](https://github.com/shoelace-style/shoelace/fork) on GitHub, clone it locally, and install its dependencies.
 
 ```bash
 git clone https://github.com/YOUR_GITHUB_USERNAME/shoelace


### PR DESCRIPTION
This PR adds Gitpod setup (cloud development in the browser).
It adds a yml file (`.gitpod.yml`) which include the setup (`npm install`, vscode extensions, etc)

You can try it here using this link (Opens this PR in Gitpod)
https://gitpod.io/#https://github.com/shoelace-style/shoelace/pull/661

![image](https://user-images.githubusercontent.com/22901/151998883-84783f12-a490-4d75-96a0-458e3cb3e8a2.png)
