### PR TITLE
Divider: added `--spacing` css property to docs

### DIFF
--- a/src/components/divider/divider.ts
+++ b/src/components/divider/divider.ts
@@ -9,6 +9,7 @@ import { watch } from '~/internal/watch';
  *
  * @cssproperty --color - The color of the divider.
  * @cssproperty --width - The width of the divider.
+ * @cssproperty --spacing - The spacing of the divider.
  */
 @customElement('sl-divider')
 export default class SlDivider extends LitElement {


### PR DESCRIPTION
Hi, I've recognized that the css custom property `--spacing` was missing within the docs, so I've added it.