### PR TITLE
fix: tab group indicator offset when element is animated

### DIFF
--- a/src/components/tab-group/tab-group.ts
+++ b/src/components/tab-group/tab-group.ts
@@ -298,11 +298,14 @@ export default class SlTabGroup extends LitElement {
     // offsetLeft/offsetTop cannot be used directly here due to a shadow parent issue: https://bugs.chromium.org/p/chromium/issues/detail?id=920069
     // neither can getBoundingClientRect as it gives invalid values for animating elements
     const allTabs = this.getAllTabs();
-    const preceedingTabs = allTabs.slice(0, allTabs.indexOf(currentTab))
-    const offset = preceedingTabs.reduce((previous, current) => ({
-      left: previous.left + current.clientWidth,
-      top: previous.top + current.clientHeight
-    }), { left: 0, top: 0 })
+    const preceedingTabs = allTabs.slice(0, allTabs.indexOf(currentTab));
+    const offset = preceedingTabs.reduce(
+      (previous, current) => ({
+        left: previous.left + current.clientWidth,
+        top: previous.top + current.clientHeight
+      }),
+      { left: 0, top: 0 }
+    );
 
     switch (this.placement) {
       case 'top':


### PR DESCRIPTION
Fixes issue #622.

On opening a dialog, the element and children initially appear at a scale of 0.8 then animate to 1.0.

The tab indicator position was being calculated at the 0.8 scale and not updating, causing it to be incorrect when the animation ends. Increasing the duration of the animation demonstrates this issue more clearly. 

`getBoundingClientRect` was replaced with a solution using `clientWidth`, which ignores animations.

`offsetLeft` would have been more straight forward however this is not possible due to a bug with shadow parents.

Some other solutions I considered felt more convoluted:

* Waiting for animation to end then calculating offset
* Replacing `getOffset()` entirely