### PR TITLE
fix: wait for animation in SlDetails

### DIFF
--- a/src/components/details/details.ts
+++ b/src/components/details/details.ts
@@ -113,7 +113,7 @@ export default class SlDetails extends LitElement {
       // Show
       emit(this, 'sl-show');
 
-      await stopAnimations(this);
+      await stopAnimations(this.body);
       this.body.hidden = false;
 
       const { keyframes, options } = getAnimation(this, 'details.show');
@@ -125,7 +125,7 @@ export default class SlDetails extends LitElement {
       // Hide
       emit(this, 'sl-hide');
 
-      await stopAnimations(this);
+      await stopAnimations(this.body);
 
       const { keyframes, options } = getAnimation(this, 'details.hide');
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);


### PR DESCRIPTION
Fixes issue #662.

SlDetails was waiting for animations to finish on a different target element. This caused a bad layout when the element is clicked during an animation.