### PR TITLE
Fixed disabled dropdowns entering open state

### DIFF
--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -234,7 +234,7 @@ export default class SlDropdown extends LitElement {
   }
 
   handleTriggerClick() {
-    if (this.open) {
+    if (this.disabled || this.open) {
       this.hide();
     } else {
       this.show();


### PR DESCRIPTION
Dropdowns can enter an illegal state:
1. disable a dropdown
2. click it
3. remove disable

The dropdown is now 'open' without showing the panel, so the user has to click it twice to show the panel.

This PR makes the disable one-way, i.e. clicking will close a disabled dropdown but never enter an open state.