### PR TITLE
Added `placement` property to `sl-select`

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -394,6 +394,33 @@ const App = () => (
 );
 ```
 
+### Placement
+
+The preferred placement of the dropdown can be set with the `placement` attribute. Note that the actual position may vary to ensure the panel remains in the viewport.
+
+```html preview
+<sl-select placement="top-start">
+  <sl-menu-item value="option-1">Option 1</sl-menu-item>
+  <sl-menu-item value="option-2">Option 2</sl-menu-item>
+  <sl-menu-item value="option-3">Option 3</sl-menu-item>
+</sl-select>
+```
+
+```jsx react
+import { 
+  SlMenuItem,
+  SlSelect
+} from '@shoelace-style/shoelace/dist/react';
+
+const App = () => (
+  <SlSelect placement="top-start">
+    <SlMenuItem value="option-1">Option 1</SlMenuItem>
+    <SlMenuItem value="option-2">Option 2</SlMenuItem>
+    <SlMenuItem value="option-3">Option 3</SlMenuItem>
+  </SlDropdown> 
+);
+```
+
 ### Prefix & Suffix Icons
 
 Use the `prefix` and `suffix` slots to add icons.

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -399,7 +399,7 @@ const App = () => (
 The preferred placement of the dropdown can be set with the `placement` attribute. Note that the actual position may vary to ensure the panel remains in the viewport.
 
 ```html preview
-<sl-select placement="top-start">
+<sl-select placement="top">
   <sl-menu-item value="option-1">Option 1</sl-menu-item>
   <sl-menu-item value="option-2">Option 2</sl-menu-item>
   <sl-menu-item value="option-3">Option 3</sl-menu-item>
@@ -413,7 +413,7 @@ import {
 } from '@shoelace-style/shoelace/dist/react';
 
 const App = () => (
-  <SlSelect placement="top-start">
+  <SlSelect placement="top">
     <SlMenuItem value="option-1">Option 1</SlMenuItem>
     <SlMenuItem value="option-2">Option 2</SlMenuItem>
     <SlMenuItem value="option-3">Option 3</SlMenuItem>

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -125,19 +125,7 @@ export default class SlSelect extends LitElement {
    * The preferred placement of the dropdown panel. Note that the actual placement may vary as needed to keep the panel
    * inside of the viewport.
    */
-  @property() placement:
-    | 'top'
-    | 'top-start'
-    | 'top-end'
-    | 'bottom'
-    | 'bottom-start'
-    | 'bottom-end'
-    | 'right'
-    | 'right-start'
-    | 'right-end'
-    | 'left'
-    | 'left-start'
-    | 'left-end' = 'bottom-start';
+  @property() placement: 'top' | 'bottom' = 'bottom';
 
   /** The select's help text. Alternatively, you can use the help-text slot. */
   @property({ attribute: 'help-text' }) helpText = '';

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -121,6 +121,24 @@ export default class SlSelect extends LitElement {
   /** The select's label. Alternatively, you can use the label slot. */
   @property() label = '';
 
+  /**
+   * The preferred placement of the dropdown panel. Note that the actual placement may vary as needed to keep the panel
+   * inside of the viewport.
+   */
+  @property() placement:
+    | 'top'
+    | 'top-start'
+    | 'top-end'
+    | 'bottom'
+    | 'bottom-start'
+    | 'bottom-end'
+    | 'right'
+    | 'right-start'
+    | 'right-end'
+    | 'left'
+    | 'left-start'
+    | 'left-end' = 'bottom-start';
+
   /** The select's help text. Alternatively, you can use the help-text slot. */
   @property({ attribute: 'help-text' }) helpText = '';
 
@@ -451,6 +469,7 @@ export default class SlSelect extends LitElement {
         <sl-dropdown
           part="base"
           .hoist=${this.hoist}
+          .placement=${this.placement}
           .stayOpenOnSelect=${this.multiple}
           .containingElement=${this as HTMLElement}
           ?disabled=${this.disabled}


### PR DESCRIPTION
Hi, I had the following issue:
`sl-dropdown` has a property `placement` to set the preferred position of the dropdown.
I also wanted to use this feature for `sl-select`, but the property doesn't exist there.

To solve this I've added the property `placement` to `sl-select` and pass it to the inner `sl-dropdown`.