### PR TITLE
Fix broken link to design tokens in docs

### DIFF
--- a/docs/getting-started/customizing.md
+++ b/docs/getting-started/customizing.md
@@ -29,7 +29,7 @@ To customize a design token, simply override it in your stylesheet using a `:roo
 }
 ```
 
-Many design tokens are described further along in this documentation. For a complete list, refer to `src/themes/light.styles.ts` in the project's [source code](https://github.com/shoelace-style/shoelace/blob/current/src/themes/light.styles.ts).
+Many design tokens are described further along in this documentation. For a complete list, refer to `src/themes/light.css` in the project's [source code](https://github.com/shoelace-style/shoelace/blob/current/src/themes/light.css).
 
 ## Component Parts
 


### PR DESCRIPTION
`light.styles.ts` no longer exists and has been replaced with `light.css`