### PR TITLE
Reflecting `name` and `library` in `sl-icon`

### DIFF
--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -26,7 +26,7 @@ export default class SlIcon extends LitElement {
   @state() private svg = '';
 
   /** The name of the icon to draw. */
-  @property() name?: string;
+  @property({ reflect: true }) name?: string;
 
   /**
    * An external URL of an SVG file.
@@ -39,7 +39,7 @@ export default class SlIcon extends LitElement {
   @property() label = '';
 
   /** The name of a registered custom icon library. */
-  @property() library = 'default';
+  @property({ reflect: true }) library = 'default';
 
   connectedCallback() {
     super.connectedCallback();


### PR DESCRIPTION
Hi, I've followed the discussion in #741.
You said that you are open to reflect `name` and `library` in `sl-icon`
I'm actually using the `name` of icons to target for CSS, so I've made them reflective.