### PR TITLE
Prevent toggling password & clearing on disabled form controls

### DIFF
--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -262,7 +262,7 @@ export default css`
   }
 
   .input__clear:hover,
-  .input__password-toggle:not([disabled]):hover {
+  .input__password-toggle:hover {
     color: var(--sl-input-icon-color-hover);
   }
 

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -262,7 +262,7 @@ export default css`
   }
 
   .input__clear:hover,
-  .input__password-toggle:hover {
+  .input__password-toggle:not([disabled]):hover {
     color: var(--sl-input-icon-color-hover);
   }
 

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -378,7 +378,7 @@ export default class SlInput extends LitElement {
               @blur=${this.handleBlur}
             />
 
-            ${this.clearable && this.value.length > 0
+            ${this.clearable && !this.disabled && this.value.length > 0
               ? html`
                   <button
                     part="clear-button"
@@ -402,6 +402,7 @@ export default class SlInput extends LitElement {
                     type="button"
                     aria-label=${this.localize.term(this.isPasswordVisible ? 'hidePassword' : 'showPassword')}
                     @click=${this.handlePasswordToggle}
+                    ?disabled=${this.disabled}
                     tabindex="-1"
                   >
                     ${this.isPasswordVisible

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -297,6 +297,7 @@ export default class SlInput extends LitElement {
     const hasHelpTextSlot = this.hasSlotController.test('help-text');
     const hasLabel = this.label ? true : !!hasLabelSlot;
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
+    const hasClearIcon = this.clearable && !this.disabled && !this.readonly && this.value.length > 0;
 
     return html`
       <div
@@ -378,7 +379,7 @@ export default class SlInput extends LitElement {
               @blur=${this.handleBlur}
             />
 
-            ${this.clearable && !this.disabled && this.value.length > 0
+            ${hasClearIcon
               ? html`
                   <button
                     part="clear-button"
@@ -394,7 +395,7 @@ export default class SlInput extends LitElement {
                   </button>
                 `
               : ''}
-            ${this.togglePassword
+            ${this.togglePassword && !this.disabled
               ? html`
                   <button
                     part="password-toggle-button"
@@ -402,7 +403,6 @@ export default class SlInput extends LitElement {
                     type="button"
                     aria-label=${this.localize.term(this.isPasswordVisible ? 'hidePassword' : 'showPassword')}
                     @click=${this.handlePasswordToggle}
-                    ?disabled=${this.disabled}
                     tabindex="-1"
                   >
                     ${this.isPasswordVisible

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -450,6 +450,7 @@ export default class SlSelect extends LitElement {
     const hasSelection = this.multiple ? this.value.length > 0 : this.value !== '';
     const hasLabel = this.label ? true : !!hasLabelSlot;
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
+    const hasClearIcon = this.clearable && !this.disabled && hasSelection;
 
     return html`
       <div
@@ -530,7 +531,7 @@ export default class SlSelect extends LitElement {
                   : this.placeholder}
               </div>
 
-              ${this.clearable && !this.disabled && hasSelection
+              ${hasClearIcon
                 ? html`
                     <button
                       part="clear-button"

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -530,7 +530,7 @@ export default class SlSelect extends LitElement {
                   : this.placeholder}
               </div>
 
-              ${this.clearable && hasSelection
+              ${this.clearable && !this.disabled && hasSelection
                 ? html`
                     <button
                       part="clear-button"


### PR DESCRIPTION
Fixes #745 

Hi @claviska ,
I've disabled the `toggle-password` button if the `sl-input` is disabled.
I've also hidden the `clearable` icon on disabled inputs & selects because I think this should also not be possible on disabled form controls. The reason why I'm completely hiding the icon is that you can't really see that it's disabled and you already hiding it if the form control is empty.
As I mentioned in the issue, I think that a readonly `toggle-password` input still should have the toggle enabled.
If you disagree you can say what I should change.