### PR TITLE
Locking of items in sl-select (multiple mode)

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -318,6 +318,40 @@ const App = () => (
 
 ?> When using the `multiple` option, the value will be an array instead of a string. You may need to [set the selection imperatively](#setting-the-selection-imperatively) unless you're using a framework that supports binding properties declaratively.
 
+### Multiple with locked options
+
+To lock certain items from being deselected, use the `locked` and `disabled` attributes on the `sl-menu-item`.
+
+```html preview
+<sl-select placeholder="Select a few" value="option-1" multiple clearable>
+  <sl-menu-item value="option-1" disabled locked>Option 1</sl-menu-item>
+  <sl-menu-item value="option-2">Option 2</sl-menu-item>
+  <sl-menu-item value="option-3">Option 3</sl-menu-item>
+  <sl-divider></sl-divider>
+  <sl-menu-item value="option-4">Option 4</sl-menu-item>
+  <sl-menu-item value="option-5">Option 5</sl-menu-item>
+  <sl-menu-item value="option-6">Option 6</sl-menu-item>
+</sl-select>
+```
+
+```jsx react
+import { SlDivider, SlMenuItem, SlSelect } from '@shoelace-style/shoelace/dist/react';
+
+const App = () => (
+  <SlSelect placeholder="Select a few" multiple clearable>
+    <SlMenuItem value="option-1" disabled locked>
+      Option 1
+    </SlMenuItem>
+    <SlMenuItem value="option-2">Option 2</SlMenuItem>
+    <SlMenuItem value="option-3">Option 3</SlMenuItem>
+    <SlDivider />
+    <SlMenuItem value="option-4">Option 4</SlMenuItem>
+    <SlMenuItem value="option-5">Option 5</SlMenuItem>
+    <SlMenuItem value="option-6">Option 6</SlMenuItem>
+  </SlSelect>
+);
+```
+
 ### Grouping Options
 
 Options can be grouped visually using menu labels and dividers.

--- a/src/components/menu-item/menu-item.ts
+++ b/src/components/menu-item/menu-item.ts
@@ -43,6 +43,9 @@ export default class SlMenuItem extends LitElement {
   /** Draws the menu item in a disabled state. */
   @property({ type: Boolean, reflect: true }) disabled = false;
 
+  /** The item is not removable from a sl-select. */
+  @property({ type: Boolean, reflect: true }) locked = false;
+
   firstUpdated() {
     this.setAttribute('role', 'menuitem');
   }

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -196,7 +196,18 @@ export default class SlSelect extends LitElement {
 
   handleClearClick(event: MouseEvent) {
     event.stopPropagation();
-    this.value = this.multiple ? [] : '';
+    if (this.multiple) {
+      const newValue: string[] = [];
+      (this.value as string[]).forEach((element: string) => {
+        if (this.menuItems.find(item => item.value === element)?.locked ?? false) {
+          newValue.push(element);
+        }
+        this.value = newValue;
+      });
+    } else {
+      this.value = '';
+    }
+
     emit(this, 'sl-clear');
     this.syncItemsFromValue();
   }
@@ -390,7 +401,7 @@ export default class SlSelect extends LitElement {
             variant="neutral"
             size=${this.size}
             ?pill=${this.pill}
-            removable
+            ?removable=${!item.locked}
             @click=${this.handleTagInteraction}
             @keydown=${this.handleTagInteraction}
             @sl-remove=${(event: CustomEvent) => {

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -202,8 +202,8 @@ export default class SlSelect extends LitElement {
         if (this.menuItems.find(item => item.value === element)?.locked ?? false) {
           newValue.push(element);
         }
-        this.value = newValue;
       });
+      this.value = newValue;
     } else {
       this.value = '';
     }


### PR DESCRIPTION
This feature makes it possible to lock certain items from being deselected.

For this I implemented a new property (`locked`) on `sl-menu-item`.

Maybe it would be better to remove it and lock the item from being deselected if the item is `disabled`. But I'm not sure if this is desired.