### PR TITLE
Fixes for clear icon in `sl-input`

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -12,6 +12,7 @@
     "bezier",
     "boxicons",
     "chatbubble",
+    "checkmark",
     "claviska",
     "Clippy",
     "codepen",

--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -6,6 +6,15 @@ Components with the <sl-badge variant="warning" pill>Experimental</sl-badge> bad
 
 _During the beta period, these restrictions may be relaxed in the event of a mission-critical bug._ 🐛
 
+## Next
+
+- Added styles to required form controls so they show an asterisk next to the label by default
+- Added the `--sl-input-required-content` design token
+- Added the `required` attribute to `<sl-radio-group>` and fixed constraint validation logic to support custom validation
+- Added the `checked-icon` part to `<sl-menu-item>`
+- Fixed a bug where a duplicate clear button showed in Firefox [#791](https://github.com/shoelace-style/shoelace/issues/791)
+- Updated the `fieldset` attribute so it reflects in `<sl-radio-group>`
+
 ## 2.0.0-beta.76
 
 - Added support for RTL animations in the Animation Registry

--- a/src/components/checkbox/checkbox.styles.ts
+++ b/src/components/checkbox/checkbox.styles.ts
@@ -103,4 +103,9 @@ export default css`
     margin-inline-start: 0.5em;
     user-select: none;
   }
+
+  :host([required]) .checkbox__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
 `;

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -281,8 +281,9 @@ export default css`
     display: none;
   }
 
-  /* Don't show the firefox clear icon in Firefox */
-  .hide-firefox-clear-icon {
+  /** Hide Firefox's clear button on date and time inputs */
+  .input--is-firefox input[type='date'],
+  .input--is-firefox input[type='time'] {
     clip-path: inset(0 2em 0 0);
   }
 `;

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -280,4 +280,9 @@ export default css`
   ::-ms-reveal {
     display: none;
   }
+
+  /* Don't show the firefox clear icon in Firefox */
+  .hide-firefox-clear-icon {
+    clip-path: inset(0 2em 0 0);
+  }
 `;

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -451,4 +451,7 @@ declare global {
   interface HTMLElementTagNameMap {
     'sl-input': SlInput;
   }
+  interface Window {
+    InstallTrigger: unknown;
+  }
 }

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -301,8 +301,6 @@ export default class SlInput extends LitElement {
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
     const hasClearIcon =
       this.clearable && !this.disabled && !this.readonly && (typeof this.value === 'number' || this.value.length > 0);
-    const isFirefox = typeof window.InstallTrigger !== 'undefined';
-    const hideFirefoxClearIcon = isFirefox && (this.type === 'date' || this.type === 'time');
 
     return html`
       <div
@@ -359,10 +357,7 @@ export default class SlInput extends LitElement {
             <input
               part="input"
               id="input"
-              class="${classMap({
-                input__control: true,
-                'hide-firefox-clear-icon': hideFirefoxClearIcon
-              })}"
+              class="input__control"
               type=${this.type === 'password' && this.isPasswordVisible ? 'text' : this.type}
               name=${ifDefined(this.name)}
               ?disabled=${this.disabled}

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -301,6 +301,8 @@ export default class SlInput extends LitElement {
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
     const hasClearIcon =
       this.clearable && !this.disabled && !this.readonly && (typeof this.value === 'number' || this.value.length > 0);
+    const isFirefox = typeof window.InstallTrigger !== 'undefined';
+    const hideFirefoxClearIcon = isFirefox && (this.type === 'date' || this.type === 'time');
 
     return html`
       <div
@@ -351,7 +353,10 @@ export default class SlInput extends LitElement {
             <input
               part="input"
               id="input"
-              class="input__control"
+              class="${classMap({
+                input__control: true,
+                'hide-firefox-clear-icon': hideFirefoxClearIcon
+              })}"
               type=${this.type === 'password' && this.isPasswordVisible ? 'text' : this.type}
               name=${ifDefined(this.name)}
               ?disabled=${this.disabled}

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -299,7 +299,8 @@ export default class SlInput extends LitElement {
     const hasHelpTextSlot = this.hasSlotController.test('help-text');
     const hasLabel = this.label ? true : !!hasLabelSlot;
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
-    const hasClearIcon = this.clearable && !this.disabled && !this.readonly && this.value.length > 0;
+    const hasClearIcon =
+      this.clearable && !this.disabled && !this.readonly && (typeof this.value === 'number' || this.value.length > 0);
 
     return html`
       <div

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -457,7 +457,4 @@ declare global {
   interface HTMLElementTagNameMap {
     'sl-input': SlInput;
   }
-  interface Window {
-    InstallTrigger: unknown;
-  }
 }

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -343,7 +343,13 @@ export default class SlInput extends LitElement {
               'input--disabled': this.disabled,
               'input--focused': this.hasFocus,
               'input--empty': !this.value,
-              'input--invalid': this.invalid
+              'input--invalid': this.invalid,
+
+              // It's currently impossible to hide Firefox's built-in clear icon when using <input type="date|time">, so
+              // we need this check to apply a clip-path to hide it. I know, I know...user agent sniffing is nasty but
+              // if it fails, we only see a redundant clear icon so nothing important is breaking. The benefits outweigh
+              // the costs for this one. See the discussion at: https://github.com/shoelace-style/shoelace/pull/794
+              'input--is-firefox': navigator.userAgent.includes('Firefox')
             })}
           >
             <span part="prefix" class="input__prefix">

--- a/src/components/menu-item/menu-item.ts
+++ b/src/components/menu-item/menu-item.ts
@@ -21,6 +21,7 @@ import styles from './menu-item.styles';
  * @slot suffix - Used to append an icon or similar element to the menu item.
  *
  * @csspart base - The component's internal wrapper.
+ * @csspart checked-icon - The checkmark's container, only visible when the menu item is checked.
  * @csspart prefix - The prefix container.
  * @csspart label - The menu item label.
  * @csspart suffix - The suffix container.
@@ -88,7 +89,7 @@ export default class SlMenuItem extends LitElement {
           'menu-item--has-submenu': false // reserved for future use
         })}
       >
-        <span class="menu-item__check">
+        <span part="checked-icon" class="menu-item__check">
           <sl-icon name="check-lg" library="system" aria-hidden="true"></sl-icon>
         </span>
 

--- a/src/components/radio-button/radio-button.styles.ts
+++ b/src/components/radio-button/radio-button.styles.ts
@@ -3,6 +3,7 @@ import buttonStyles from '../button/button.styles';
 
 export default css`
   ${buttonStyles}
+
   label {
     display: inline-block;
     position: relative;

--- a/src/components/radio-group/radio-group.styles.ts
+++ b/src/components/radio-group/radio-group.styles.ts
@@ -44,4 +44,9 @@ export default css`
     overflow: hidden;
     white-space: nowrap;
   }
+
+  .radio-group--required .radio-group__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: -2px;
+  }
 `;

--- a/src/components/radio-group/radio-group.test.ts
+++ b/src/components/radio-group/radio-group.test.ts
@@ -1,0 +1,61 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import type SlRadio from '../radio/radio';
+import type SlRadioGroup from './radio-group';
+
+describe('<sl-radio-group>', () => {
+  describe('validation tests', () => {
+    it(`should be valid when required and one radio is checked`, async () => {
+      const el = await fixture<SlRadioGroup>(html`
+        <sl-radio-group label="Select an option" required>
+          <sl-radio name="option" value="1" checked>Option 1</sl-radio>
+          <sl-radio name="option" value="2">Option 2</sl-radio>
+          <sl-radio name="option" value="3">Option 3</sl-radio>
+        </sl-radio-group>
+      `);
+      const radio = el.querySelector<SlRadio>('sl-radio')!;
+
+      expect(radio.reportValidity()).to.be.true;
+    });
+
+    it(`should be invalid when required and no radios are checked`, async () => {
+      const el = await fixture<SlRadioGroup>(html`
+        <sl-radio-group label="Select an option" required>
+          <sl-radio name="option" value="1">Option 1</sl-radio>
+          <sl-radio name="option" value="2">Option 2</sl-radio>
+          <sl-radio name="option" value="3">Option 3</sl-radio>
+        </sl-radio-group>
+      `);
+      const radio = el.querySelector<SlRadio>('sl-radio')!;
+
+      expect(radio.reportValidity()).to.be.false;
+    });
+
+    it(`should be valid when required and a different radio is checked`, async () => {
+      const el = await fixture<SlRadioGroup>(html`
+        <sl-radio-group label="Select an option" required>
+          <sl-radio name="option" value="1">Option 1</sl-radio>
+          <sl-radio name="option" value="2">Option 2</sl-radio>
+          <sl-radio name="option" value="3" checked>Option 3</sl-radio>
+        </sl-radio-group>
+      `);
+      const radio = el.querySelectorAll('sl-radio')![2];
+
+      expect(radio.reportValidity()).to.be.true;
+    });
+
+    it(`should be invalid when custom validity is set`, async () => {
+      const el = await fixture<SlRadioGroup>(html`
+        <sl-radio-group label="Select an option">
+          <sl-radio name="option" value="1">Option 1</sl-radio>
+          <sl-radio name="option" value="2">Option 2</sl-radio>
+          <sl-radio name="option" value="3">Option 3</sl-radio>
+        </sl-radio-group>
+      `);
+      const radio = el.querySelector<SlRadio>('sl-radio')!;
+
+      radio.setCustomValidity('Error');
+
+      expect(radio.reportValidity()).to.be.false;
+    });
+  });
+});

--- a/src/components/radio-group/radio-group.ts
+++ b/src/components/radio-group/radio-group.ts
@@ -33,7 +33,10 @@ export default class SlRadioGroup extends LitElement {
   @property() label = '';
 
   /** Shows the fieldset and legend that surrounds the radio group. */
-  @property({ type: Boolean, attribute: 'fieldset' }) fieldset = false;
+  @property({ type: Boolean, attribute: 'fieldset', reflect: true }) fieldset = false;
+
+  /** Ensures a child radio is checked before allowing the containing form to submit. */
+  @property({ type: Boolean, reflect: true }) required = false;
 
   connectedCallback() {
     super.connectedCallback();
@@ -89,7 +92,7 @@ export default class SlRadioGroup extends LitElement {
     const radios = this.getAllRadios();
     const checkedRadio = radios.find(radio => radio.checked);
 
-    this.hasButtonGroup = !!radios.find(radio => radio.tagName.toLowerCase() === 'sl-radio-button');
+    this.hasButtonGroup = radios.some(radio => radio.tagName.toLowerCase() === 'sl-radio-button');
 
     radios.forEach(radio => {
       radio.setAttribute('role', 'radio');
@@ -113,7 +116,8 @@ export default class SlRadioGroup extends LitElement {
         part="base"
         class=${classMap({
           'radio-group': true,
-          'radio-group--has-fieldset': this.fieldset
+          'radio-group--has-fieldset': this.fieldset,
+          'radio-group--required': this.required
         })}
       >
         <legend part="label" class="radio-group__label">

--- a/src/components/switch/switch.styles.ts
+++ b/src/components/switch/switch.styles.ts
@@ -134,4 +134,9 @@ export default css`
     margin-inline-start: 0.5em;
     user-select: none;
   }
+
+  :host([required]) .switch__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
 `;

--- a/src/styles/form-control.styles.ts
+++ b/src/styles/form-control.styles.ts
@@ -28,6 +28,11 @@ export default css`
     font-size: var(--sl-input-label-font-size-large);
   }
 
+  :host([required]) .form-control--has-label .form-control__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
+
   /* Help text */
   .form-control--has-help-text .form-control__help-text {
     display: block;

--- a/src/themes/dark.css
+++ b/src/themes/dark.css
@@ -432,6 +432,8 @@
   --sl-input-border-color-focus: var(--sl-color-primary-500);
   --sl-input-border-color-disabled: var(--sl-color-neutral-300);
   --sl-input-border-width: 1px;
+  --sl-input-required-content: '*';
+  --sl-input-required-content-offset: -2px;
 
   --sl-input-border-radius-small: var(--sl-border-radius-medium);
   --sl-input-border-radius-medium: var(--sl-border-radius-medium);

--- a/src/themes/light.css
+++ b/src/themes/light.css
@@ -432,6 +432,8 @@
   --sl-input-border-color-focus: var(--sl-color-primary-500);
   --sl-input-border-color-disabled: var(--sl-color-neutral-300);
   --sl-input-border-width: 1px;
+  --sl-input-required-content: '*';
+  --sl-input-required-content-offset: -2px;
 
   --sl-input-border-radius-small: var(--sl-border-radius-medium);
   --sl-input-border-radius-medium: var(--sl-border-radius-medium);


### PR DESCRIPTION
Fixes #793 Fixes #791 
This PR fixes the clear icon doesn't appear if a value with type `number ` is assigned to a `sl-input`.
While fixing this I thought I can also fix the thing with the two clear icons in Firefox. I've done this with `clip-path` which I only set in Firefox on type `date` and `time`.