### PR TITLE
 Algorithm fix: fill "allElements" with only unique elements to improve performance.

### DIFF
--- a/src/internal/tabbable.ts
+++ b/src/internal/tabbable.ts
@@ -67,7 +67,7 @@ export function getTabbableBoundary(root: HTMLElement | ShadowRoot) {
       }
     }
 
-    [...el.querySelectorAll('*')].forEach((e: HTMLElement) => walk(e));
+    [...el.children].forEach((e: HTMLElement) => walk(e));
   }
 
   // Collect all elements including the root


### PR DESCRIPTION
Function `walk` calls many times for same elements, and `allElements` array has a millions elements. This can freeze UI for a few seconds.