### PR TITLE
docs: Note that releases are not on a schedule

### DIFF
--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -4,6 +4,8 @@ Shoelace follows [Semantic Versioning](https://semver.org/). Breaking changes in
 
 Components with the <sl-badge variant="warning" pill>Experimental</sl-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+Shoelace releases currently do not adhere to a set schedule. New releases are published when a critical mass of relevant changes is accumulated.
+
 _During the beta period, these restrictions may be relaxed in the event of a mission-critical bug._ 🐛
 
 ## Next


### PR DESCRIPTION
As I was wondering about this when I adopted Shoelace, I figured maybe it could go into the docs. Maybe you'll find a better way to phrase it though :D