### PR TITLE
Fix minor changelog markup issue

### DIFF
--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -15,7 +15,7 @@ _During the beta period, these restrictions may be relaxed in the event of a mis
 - Added Swedish translation [#838](https://github.com/shoelace-style/shoelace/pull/838)
 - Added support for `step="any"` for `<sl-input type="number">` [#839](https://github.com/shoelace-style/shoelace/issues/839)
 - Changed the type of component styles from `CSSResult` to `CSSResultGroup` [#828](https://github.com/shoelace-style/shoelace/issues/828)
-- Fixed a bug in `<sl-color-picker>` where using <kbd>Left<kbd> and <kbd>Right</kbd> would select the wrong color
+- Fixed a bug in `<sl-color-picker>` where using <kbd>Left</kbd> and <kbd>Right</kbd> would select the wrong color
 - Fixed a bug in `<sl-dropdown>` that caused the position to be incorrect on the first show when using `hoist` [#843](https://github.com/shoelace-style/shoelace/issues/843)
 - Fixed a bug in `<sl-tab-group>` where the divider was on the wrong side when using `placement="end"`
 - Fixed a bug in `<sl-tab-group>` that caused nested tab groups to scroll when using `placement="start|end"` [#815](https://github.com/shoelace-style/shoelace/issues/815)


### PR DESCRIPTION
This PR adds the proper `</kbd>` closing tag to restore the correct markup for the changelog.

Before the change:

![image](https://user-images.githubusercontent.com/5441654/182310331-8f8788e7-94ac-41e7-a348-3cf1b41d25a4.png)

After the change:

![image](https://user-images.githubusercontent.com/5441654/182310301-c1aca58c-744a-4c10-8e81-35b5320d4dae.png)
