### PR TITLE
Avoid bubbling events for sl-include

### DIFF
--- a/docs/components/include.md
+++ b/docs/components/include.md
@@ -32,13 +32,13 @@ If the request fails, the `sl-error` event will be emitted. In this case, `event
 <script>
   const include = document.querySelector('sl-include');
 
-  include.addEventListener('sl-load', () => {
-    if (e.eventPhase !== 2) return;
+  include.addEventListener('sl-load', event => {
+    if (event.eventPhase !== 2) return;
     console.log('Success');
   });
 
   include.addEventListener('sl-error', event => {
-    if (e.eventPhase !== 2) return;
+    if (event.eventPhase !== 2) return;
     console.log('Error', event.detail.status);
   });
 </script>

--- a/docs/components/include.md
+++ b/docs/components/include.md
@@ -33,10 +33,12 @@ If the request fails, the `sl-error` event will be emitted. In this case, `event
   const include = document.querySelector('sl-include');
 
   include.addEventListener('sl-load', () => {
+    if (e.eventPhase !== 2) return;
     console.log('Success');
   });
 
   include.addEventListener('sl-error', event => {
+    if (e.eventPhase !== 2) return;
     console.log('Error', event.detail.status);
   });
 </script>


### PR DESCRIPTION
I ran into an issue where icons inside of an HTML include were dispatching `sl-load` events, which was causing my `sl-include` event handler to run multiple times. By adding these guards, we ensure only events immediately dispatched by the element itself will be handled.

FYI I originally used the `e.target !== e.currentTarget` trick, but this seems to be a cleaner implementation.