### PR TITLE
Display error messages under input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .cache
+.idea
 docs/dist
 docs/search.json
 dist

--- a/src/components/checkbox/checkbox.styles.ts
+++ b/src/components/checkbox/checkbox.styles.ts
@@ -104,4 +104,9 @@ export default css`
     content: var(--sl-input-required-content);
     margin-inline-start: var(--sl-input-required-content-offset);
   }
+
+  .checkbox__error-text {
+    font-size: var(--sl-input-help-text-font-size-medium);
+    color: var(--sl-input-error-text-color);
+  }
 `;

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -66,6 +66,8 @@ export default class SlCheckbox extends ShoelaceElement {
   @defaultValue('checked')
   defaultChecked = false;
 
+  @state() protected validationMessage = '';
+
   firstUpdated() {
     this.invalid = !this.input.checkValidity();
   }
@@ -87,7 +89,17 @@ export default class SlCheckbox extends ShoelaceElement {
 
   /** Checks for validity and shows the browser's validation message if the control is invalid. */
   reportValidity() {
-    return this.input.reportValidity();
+    this.invalid = !this.checkValidity()
+
+    this.validationMessage = this.input.validationMessage
+
+    this.requestUpdate()
+
+    return !this.invalid
+  }
+
+  checkValidity() {
+    return this.input.checkValidity()
   }
 
   /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */
@@ -186,6 +198,8 @@ export default class SlCheckbox extends ShoelaceElement {
           <slot></slot>
         </span>
       </label>
+
+      ${this.invalid ? html`<div class="checkbox__error-text">${this.validationMessage}</div>` : ''}
     `;
   }
 }

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -89,17 +89,17 @@ export default class SlCheckbox extends ShoelaceElement {
 
   /** Checks for validity and shows the browser's validation message if the control is invalid. */
   reportValidity() {
-    this.invalid = !this.checkValidity()
+    this.invalid = !this.checkValidity();
 
-    this.validationMessage = this.input.validationMessage
+    this.validationMessage = this.input.validationMessage;
 
-    this.requestUpdate()
+    this.requestUpdate();
 
-    return !this.invalid
+    return !this.invalid;
   }
 
   checkValidity() {
-    return this.input.checkValidity()
+    return this.input.checkValidity();
   }
 
   /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */

--- a/src/components/color-picker/color-picker.ts
+++ b/src/components/color-picker/color-picker.ts
@@ -260,7 +260,7 @@ export default class SlColorPicker extends ShoelaceElement {
   }
 
   checkValidity() {
-    return this.input.checkValidity()
+    return this.input.checkValidity();
   }
 
   /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */

--- a/src/components/color-picker/color-picker.ts
+++ b/src/components/color-picker/color-picker.ts
@@ -180,6 +180,8 @@ export default class SlColorPicker extends ShoelaceElement {
     '#fff'
   ];
 
+  @state() protected validationMessage = '';
+
   connectedCallback() {
     super.connectedCallback();
 
@@ -247,7 +249,18 @@ export default class SlColorPicker extends ShoelaceElement {
         this.dropdown.show();
       });
     }
-    return this.input.reportValidity();
+
+    this.invalid = !this.checkValidity();
+
+    this.validationMessage = this.input.validationMessage;
+
+    this.requestUpdate();
+
+    return !this.invalid;
+  }
+
+  checkValidity() {
+    return this.input.checkValidity()
   }
 
   /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */
@@ -924,6 +937,8 @@ export default class SlColorPicker extends ShoelaceElement {
         </button>
         ${colorPicker}
       </sl-dropdown>
+
+      ${this.invalid ? html`<div class="form-control__error-text">${this.validationMessage}</div>` : ''}
     `;
   }
 }

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -65,6 +65,8 @@ export default class SlInput extends ShoelaceElement {
   private readonly hasSlotController = new HasSlotController(this, 'help-text', 'label');
   private readonly localize = new LocalizeController(this);
 
+  validationMessage = '';
+
   @state() private hasFocus = false;
 
   /** The input's type. */
@@ -179,8 +181,6 @@ export default class SlInput extends ShoelaceElement {
 
   /** The input's inputmode attribute. */
   @property() inputmode: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
-
-  @state() protected validationMessage = '';
 
   /** Gets or sets the current value as a `Date` object. Only valid when `type` is `date`. */
   get valueAsDate() {

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -180,6 +180,8 @@ export default class SlInput extends ShoelaceElement {
   /** The input's inputmode attribute. */
   @property() inputmode: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
 
+  @state() protected validationMessage = '';
+
   /** Gets or sets the current value as a `Date` object. Only valid when `type` is `date`. */
   get valueAsDate() {
     return this.input?.valueAsDate ?? null;
@@ -252,7 +254,17 @@ export default class SlInput extends ShoelaceElement {
 
   /** Checks for validity and shows the browser's validation message if the control is invalid. */
   reportValidity() {
-    return this.input.reportValidity();
+    this.invalid = !this.checkValidity()
+
+    this.validationMessage = this.input.validationMessage
+
+    this.requestUpdate()
+
+    return !this.invalid
+  }
+
+  checkValidity() {
+    return this.input.checkValidity()
   }
 
   /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */
@@ -478,6 +490,8 @@ export default class SlInput extends ShoelaceElement {
         >
           <slot name="help-text">${this.helpText}</slot>
         </div>
+
+        ${this.invalid ? html`<div class="form-control__error-text">${this.validationMessage}</div>` : ''}
       </div>
     `;
   }

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -254,17 +254,17 @@ export default class SlInput extends ShoelaceElement {
 
   /** Checks for validity and shows the browser's validation message if the control is invalid. */
   reportValidity() {
-    this.invalid = !this.checkValidity()
+    this.invalid = !this.checkValidity();
 
-    this.validationMessage = this.input.validationMessage
+    this.validationMessage = this.input.validationMessage;
 
-    this.requestUpdate()
+    this.requestUpdate();
 
-    return !this.invalid
+    return !this.invalid;
   }
 
   checkValidity() {
-    return this.input.checkValidity()
+    return this.input.checkValidity();
   }
 
   /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -165,17 +165,17 @@ export default class SlSelect extends ShoelaceElement {
 
   /** Checks for validity and shows the browser's validation message if the control is invalid. */
   reportValidity() {
-    this.invalid = !this.checkValidity()
+    this.invalid = !this.checkValidity();
 
-    this.validationMessage = this.input.validationMessage
+    this.validationMessage = this.input.validationMessage;
 
-    this.requestUpdate()
+    this.requestUpdate();
 
-    return !this.invalid
+    return !this.invalid;
   }
 
   checkValidity() {
-    return this.input.checkValidity()
+    return this.input.checkValidity();
   }
 
   /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -142,6 +142,8 @@ export default class SlSelect extends ShoelaceElement {
   @defaultValue()
   defaultValue = '';
 
+  @state() protected validationMessage = '';
+
   connectedCallback() {
     super.connectedCallback();
     this.resizeObserver = new ResizeObserver(() => this.resizeMenu());
@@ -163,7 +165,17 @@ export default class SlSelect extends ShoelaceElement {
 
   /** Checks for validity and shows the browser's validation message if the control is invalid. */
   reportValidity() {
-    return this.input.reportValidity();
+    this.invalid = !this.checkValidity()
+
+    this.validationMessage = this.input.validationMessage
+
+    this.requestUpdate()
+
+    return !this.invalid
+  }
+
+  checkValidity() {
+    return this.input.checkValidity()
   }
 
   /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */
@@ -587,6 +599,8 @@ export default class SlSelect extends ShoelaceElement {
         >
           <slot name="help-text">${this.helpText}</slot>
         </div>
+
+        ${this.invalid ? html`<div class="form-control__error-text">${this.validationMessage}</div>` : ''}
       </div>
     `;
   }

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -119,6 +119,8 @@ export default class SlTextarea extends ShoelaceElement {
   @defaultValue()
   defaultValue = '';
 
+  @state() protected validationMessage = '';
+
   connectedCallback() {
     super.connectedCallback();
     this.resizeObserver = new ResizeObserver(() => this.setTextareaHeight());
@@ -200,7 +202,17 @@ export default class SlTextarea extends ShoelaceElement {
 
   /** Checks for validity and shows the browser's validation message if the control is invalid. */
   reportValidity() {
-    return this.input.reportValidity();
+    this.invalid = !this.checkValidity()
+
+    this.validationMessage = this.input.validationMessage
+
+    this.requestUpdate()
+
+    return !this.invalid
+  }
+
+  checkValidity() {
+    return this.input.checkValidity()
   }
 
   /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */
@@ -339,6 +351,8 @@ export default class SlTextarea extends ShoelaceElement {
         >
           <slot name="help-text">${this.helpText}</slot>
         </div>
+
+        ${this.invalid ? html`<div class="form-control__error-text">${this.validationMessage}</div>` : ''}
       </div>
     `;
   }

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -202,17 +202,17 @@ export default class SlTextarea extends ShoelaceElement {
 
   /** Checks for validity and shows the browser's validation message if the control is invalid. */
   reportValidity() {
-    this.invalid = !this.checkValidity()
+    this.invalid = !this.checkValidity();
 
-    this.validationMessage = this.input.validationMessage
+    this.validationMessage = this.input.validationMessage;
 
-    this.requestUpdate()
+    this.requestUpdate();
 
-    return !this.invalid
+    return !this.invalid;
   }
 
   checkValidity() {
-    return this.input.checkValidity()
+    return this.input.checkValidity();
   }
 
   /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */

--- a/src/styles/form-control.styles.ts
+++ b/src/styles/form-control.styles.ts
@@ -54,4 +54,9 @@ export default css`
   .form-control--has-help-text.form-control--large .form-control__help-text {
     font-size: var(--sl-input-help-text-font-size-large);
   }
+
+  .form-control__error-text {
+    font-size: var(--sl-input-help-text-font-size-medium);
+    color: var(--sl-input-error-text-color);
+  }
 `;

--- a/src/themes/dark.css
+++ b/src/themes/dark.css
@@ -485,6 +485,9 @@
 
   --sl-input-help-text-color: var(--sl-color-neutral-500);
 
+  /* Error text */
+  --sl-input-error-text-color: var(--sl-color-warning-200);
+
   /* Toggles (checkboxes, radios, switches) */
   --sl-toggle-size: 1rem;
 

--- a/src/themes/light.css
+++ b/src/themes/light.css
@@ -485,6 +485,9 @@
 
   --sl-input-help-text-color: var(--sl-color-neutral-500);
 
+  /* Error text */
+  --sl-input-error-text-color: var(--sl-color-warning-200);
+
   /* Toggles (checkboxes, radios, switches) */
   --sl-toggle-size: 1rem;
 


### PR DESCRIPTION
Display error messages under input (not in popup) and bypass `reportValidity()` method. Example:

![obrazek](https://user-images.githubusercontent.com/7465851/193662674-925a910b-2418-40b3-bf18-3a662f1c4cf4.png)
