### PR TITLE
add new theme token --sl-input-required-content-color to both themes

### DIFF
--- a/src/styles/form-control.styles.ts
+++ b/src/styles/form-control.styles.ts
@@ -31,6 +31,7 @@ export default css`
   :host([required]) .form-control--has-label .form-control__label::after {
     content: var(--sl-input-required-content);
     margin-inline-start: var(--sl-input-required-content-offset);
+    color: var(--sl-input-required-content-color);
   }
 
   /* Help text */

--- a/src/themes/dark.css
+++ b/src/themes/dark.css
@@ -434,6 +434,7 @@
   --sl-input-border-width: 1px;
   --sl-input-required-content: '*';
   --sl-input-required-content-offset: -2px;
+  --sl-input-required-content-color: var(--sl-color-danger-700);
 
   --sl-input-border-radius-small: var(--sl-border-radius-medium);
   --sl-input-border-radius-medium: var(--sl-border-radius-medium);

--- a/src/themes/dark.css
+++ b/src/themes/dark.css
@@ -434,7 +434,7 @@
   --sl-input-border-width: 1px;
   --sl-input-required-content: '*';
   --sl-input-required-content-offset: -2px;
-  --sl-input-required-content-color: var(--sl-color-danger-700);
+  --sl-input-required-content-color: var(--sl-input-label-color);
 
   --sl-input-border-radius-small: var(--sl-border-radius-medium);
   --sl-input-border-radius-medium: var(--sl-border-radius-medium);

--- a/src/themes/light.css
+++ b/src/themes/light.css
@@ -434,6 +434,7 @@
   --sl-input-border-width: 1px;
   --sl-input-required-content: '*';
   --sl-input-required-content-offset: -2px;
+  --sl-input-required-content-color: var(--sl-color-danger-700);
 
   --sl-input-border-radius-small: var(--sl-border-radius-medium);
   --sl-input-border-radius-medium: var(--sl-border-radius-medium);

--- a/src/themes/light.css
+++ b/src/themes/light.css
@@ -434,7 +434,7 @@
   --sl-input-border-width: 1px;
   --sl-input-required-content: '*';
   --sl-input-required-content-offset: -2px;
-  --sl-input-required-content-color: var(--sl-color-danger-700);
+  --sl-input-required-content-color: var(--sl-input-label-color);
 
   --sl-input-border-radius-small: var(--sl-border-radius-medium);
   --sl-input-border-radius-medium: var(--sl-border-radius-medium);


### PR DESCRIPTION
Add new theme token `--sl-input-required-content-color` with default value `var(--sl-color-danger-700)`  to style all asterisks of required input fields

Implementation for: https://github.com/shoelace-style/shoelace/issues/944