### PR TITLE
WIP: `sl-input`: add new `hidden-label` attribute

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -32,6 +32,20 @@ import { SlIcon, SlInput } from '@shoelace-style/shoelace/dist/react';
 const App = () => <SlInput label="What is your name?" />;
 ```
 
+### Hidden Labels
+
+Use the `hidden-label` attribute to hide label from user in a screen reader friendly way.
+
+```html preview
+<sl-input label="What is your name?" hidden-label></sl-input>
+```
+
+```jsx react
+import { SlIcon, SlInput } from '@shoelace-style/shoelace/dist/react';
+
+const App = () => <SlInput label="What is your name?" hidden-label />;
+```
+
 ### Help Text
 
 Add descriptive help text to an input with the `help-text` attribute. For help texts that contain HTML, use the `help-text` slot instead.

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -340,7 +340,7 @@ export default class SlInput extends ShoelaceElement {
     const hasLabelSlot = this.hasSlotController.test('label');
     const hasHelpTextSlot = this.hasSlotController.test('help-text');
     const hasLabel = this.label ? true : !!hasLabelSlot;
-    const hasHiddenLabel = this.hiddenLabel ? true : false;
+    const hasHiddenLabel = this.hiddenLabel && hasLabel ? true : false;
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
     const hasClearIcon =
       this.clearable && !this.disabled && !this.readonly && (typeof this.value === 'number' || this.value.length > 0);
@@ -362,7 +362,7 @@ export default class SlInput extends ShoelaceElement {
           part="form-control-label"
           class="form-control__label"
           for="input"
-          aria-hidden=${hasLabel && hasHiddenLabel ? 'false' : 'true'}
+          aria-hidden=${hasHiddenLabel ? 'false' : 'true'}
         >
           <slot name="label">${this.label}</slot>
         </label>

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -102,6 +102,9 @@ export default class SlInput extends ShoelaceElement {
   /** The input's label. If you need to display HTML, you can use the `label` slot instead. */
   @property() label = '';
 
+  /** Draws a hidden label only relevant for screen readers. */
+  @property({ attribute: 'hidden-label', type: Boolean, reflect: true }) hiddenLabel = false;
+
   /** The input's help text. If you need to display HTML, you can use the `help-text` slot instead. */
   @property({ attribute: 'help-text' }) helpText = '';
 
@@ -337,6 +340,7 @@ export default class SlInput extends ShoelaceElement {
     const hasLabelSlot = this.hasSlotController.test('label');
     const hasHelpTextSlot = this.hasSlotController.test('help-text');
     const hasLabel = this.label ? true : !!hasLabelSlot;
+    const hasHiddenLabel = this.hiddenLabel ? true : false;
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
     const hasClearIcon =
       this.clearable && !this.disabled && !this.readonly && (typeof this.value === 'number' || this.value.length > 0);
@@ -350,6 +354,7 @@ export default class SlInput extends ShoelaceElement {
           'form-control--medium': this.size === 'medium',
           'form-control--large': this.size === 'large',
           'form-control--has-label': hasLabel,
+          'form-control--has-hidden-label': hasLabel && hasHiddenLabel,
           'form-control--has-help-text': hasHelpText
         })}
       >
@@ -357,7 +362,7 @@ export default class SlInput extends ShoelaceElement {
           part="form-control-label"
           class="form-control__label"
           for="input"
-          aria-hidden=${hasLabel ? 'false' : 'true'}
+          aria-hidden=${hasLabel && hasHiddenLabel ? 'false' : 'true'}
         >
           <slot name="label">${this.label}</slot>
         </label>

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -340,7 +340,7 @@ export default class SlInput extends ShoelaceElement {
     const hasLabelSlot = this.hasSlotController.test('label');
     const hasHelpTextSlot = this.hasSlotController.test('help-text');
     const hasLabel = this.label ? true : !!hasLabelSlot;
-    const hasHiddenLabel = this.hiddenLabel && hasLabel ? true : false;
+    const hasHiddenLabel = this.hiddenLabel ? true : false;
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
     const hasClearIcon =
       this.clearable && !this.disabled && !this.readonly && (typeof this.value === 'number' || this.value.length > 0);
@@ -354,7 +354,7 @@ export default class SlInput extends ShoelaceElement {
           'form-control--medium': this.size === 'medium',
           'form-control--large': this.size === 'large',
           'form-control--has-label': hasLabel,
-          'form-control--has-hidden-label': hasLabel && hasHiddenLabel,
+          'form-control--has-hidden-label': hasHiddenLabel,
           'form-control--has-help-text': hasHelpText
         })}
       >
@@ -362,7 +362,7 @@ export default class SlInput extends ShoelaceElement {
           part="form-control-label"
           class="form-control__label"
           for="input"
-          aria-hidden=${hasHiddenLabel ? 'false' : 'true'}
+          aria-hidden=${hasLabel || hasHiddenLabel ? 'false' : 'true'}
         >
           <slot name="label">${this.label}</slot>
         </label>

--- a/src/styles/form-control.styles.ts
+++ b/src/styles/form-control.styles.ts
@@ -16,6 +16,17 @@ export default css`
     margin-bottom: var(--sl-spacing-3x-small);
   }
 
+  .form-control--has-label.form-control--has-hidden-label .form-control__label {
+    border: 0;
+    clip; rect(1px, 1px, 1px, 1px);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+  }
+
   .form-control--has-label.form-control--small .form-control__label {
     font-size: var(--sl-input-label-font-size-small);
   }


### PR DESCRIPTION
Triggered by https://github.com/shoelace-style/shoelace/issues/728 it should be possible to hide labels only for users, but keep them for screen readers