### PR TITLE
Enrich docs with `@summary` and `@title` from `custom-elements.json`

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -27,7 +27,7 @@ export default {
           case ts.SyntaxKind.ClassDeclaration: {
             const className = node.name.getText();
             const classDoc = moduleDoc?.declarations?.find(declaration => declaration.name === className);
-            const customTags = ['animation', 'dependency', 'since', 'status'];
+            const customTags = ['title', 'animation', 'dependency', 'since', 'status'];
             let customComments = '/**';
 
             node.jsDoc?.forEach(jsDoc => {
@@ -65,6 +65,7 @@ export default {
                 // Value-only metadata tags
                 case 'since':
                 case 'status':
+                case 'title':
                   classDoc[t.tag] = t.name;
                   break;
 

--- a/docs/assets/plugins/metadata/metadata.js
+++ b/docs/assets/plugins/metadata/metadata.js
@@ -392,6 +392,25 @@
         return result.replace(/^ +| +$/gm, '');
       });
 
+      // Handle [component-description] tags
+      content = content.replace(/\[component-description:([a-z-]+)\]/g, (match, tag) => {
+        const component = getComponent(metadata, tag);
+        let result = '';
+
+        if (!component) {
+          console.error(`Component not found in metadata: ${tag}`);
+          return next(content);
+        }
+
+        result += `
+          <div class="component-description">
+              <p>${component.description}</p>
+          </div>
+        `;
+
+        return result.replace(/^ +| +$/gm, '');
+      });
+
       // Handle [component-metadata] tags
       content = content.replace(/\[component-metadata:([a-z-]+)\]/g, (match, tag) => {
         const component = getComponent(metadata, tag);

--- a/docs/assets/plugins/metadata/metadata.js
+++ b/docs/assets/plugins/metadata/metadata.js
@@ -374,7 +374,7 @@
         result += `
           <div class="component-header">
             <div class="component-header__tag">
-              <code>&lt;${component.tagName}&gt; | ${component.name}</code>
+              <code>&lt;${component.tagName}&gt; | ${component.title ?? component.name}</code>
             </div>
 
             <div class="component-header__info">
@@ -386,25 +386,10 @@
                 ${component.status}
               </sl-badge>
             </div>
-          </div>
-        `;
 
-        return result.replace(/^ +| +$/gm, '');
-      });
-
-      // Handle [component-description] tags
-      content = content.replace(/\[component-description:([a-z-]+)\]/g, (match, tag) => {
-        const component = getComponent(metadata, tag);
-        let result = '';
-
-        if (!component) {
-          console.error(`Component not found in metadata: ${tag}`);
-          return next(content);
-        }
-
-        result += `
-          <div class="component-description">
-              <p>${component.description}</p>
+            <div class="component-header__summary">
+              <p>${component.summary}</p>
+            </div>
           </div>
         `;
 

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -533,7 +533,8 @@ kbd,
 }
 
 /* Lead sentences that occur immediately after the header */
-.component-header + p {
+.component-header + p,
+.component-description {
   font-size: var(--sl-font-size-large);
   line-height: 1.6;
 }

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -534,7 +534,7 @@ kbd,
 
 /* Lead sentences that occur immediately after the header */
 .component-header + p,
-.component-description {
+.component-header p {
   font-size: var(--sl-font-size-large);
   line-height: 1.6;
 }


### PR DESCRIPTION
This is a preparation PR for https://github.com/shoelace-style/shoelace/pull/947 

Relates to https://github.com/shoelace-style/shoelace/issues/946

Docs are now enriched with `summary` and `title` from `custom-elements.json` if components JSDocs containes them.