### PR TITLE
Removed `Intl.RelativeTimeFormat` Safari support notice

### DIFF
--- a/docs/components/relative-time.md
+++ b/docs/components/relative-time.md
@@ -21,8 +21,6 @@ The `date` attribute determines when the date/time is calculated from. It must b
 
 ?> When using strings, avoid ambiguous dates such as `03/04/2020` which can be interpreted as March 4 or April 3 depending on the user's browser and locale. Instead, always use a valid [ISO 8601 date time string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Date_Time_String_Format) to ensure the date will be parsed properly by all clients.
 
-!> The `Intl.RelativeTimeFormat` API is available [in all major browsers](https://caniuse.com/mdn-javascript_builtins_intl_relativetimeformat), but it only became available to Safari in version 14. If you need to support Safari 13, you'll need to [use a polyfill](https://github.com/catamphetamine/relative-time-format).
-
 ## Examples
 
 ### Keeping Time in Sync


### PR DESCRIPTION
Hi, I've noticed that there is still a notice in the docs of `<sl-relative-time>` that Safari 13 doesn't support `Intl.RelativeTimeFormat`.
Now because the last two versions of Safari, which are the target versions for Shoelace, both support that and even Safari 16 is on it's way I thought this can be removed now.