### PR TITLE
Remove error-causing calls to removeEventListener from Dropdown

### DIFF
--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -344,8 +344,10 @@ export default class SlDropdown extends ShoelaceElement {
   }
 
   removeOpenListeners() {
-    this.panel.removeEventListener('sl-activate', this.handleMenuItemActivate);
-    this.panel.removeEventListener('sl-select', this.handlePanelSelect);
+    if (this.panel) {
+      this.panel.removeEventListener('sl-activate', this.handleMenuItemActivate);
+      this.panel.removeEventListener('sl-select', this.handlePanelSelect);
+    }
     document.removeEventListener('keydown', this.handleDocumentKeyDown);
     document.removeEventListener('mousedown', this.handleDocumentMouseDown);
   }


### PR DESCRIPTION
If the component gets disconnected before first render, `this.panel` returns null and therefore causes an error. We could be defensive and check for this.panel to be something truthy before attempting to removeEventListener, but looking at [Lit docs](https://lit.dev/docs/components/lifecycle/#disconnectedcallback) it seems like they explicitly call out that you don't need to remove event listeners from elements within the component's own DOM.