### PR TITLE
feat: support react micro-frontends

### DIFF
--- a/scripts/make-react.js
+++ b/scripts/make-react.js
@@ -38,12 +38,11 @@ components.map(component => {
     `
       import * as React from 'react';
       import { createComponent } from '@lit-labs/react';
-      import Component from '../../${importPath}';
 
       export default createComponent(
         React,
         '${component.tagName}',
-        Component,
+        window.customElements.get('${component.tagName}')!,
         {
           ${events}
         }


### PR DESCRIPTION
# Supporting react microfrontends

First of all I wanted to thank you for this fantastic library.

I'm opening this PR because I want to be able to use your library in an environment
where multiple teams deploy multiple micro frontends. The built-in react adapter is great
but if I have multiple scripts requiring it, I will have multiple instances of shoelace.

This is because the adapter explicitly requires the Component.

The fix in this case is to grab the component from the global custom element registry.
