### PR TITLE
Remove extra footer slot from Card with Footer example

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -206,7 +206,7 @@ Footers can be used to display actions, summaries, or other relevant content.
 
   <div slot="footer">
     <sl-rating></sl-rating>
-    <sl-button slot="footer" variant="primary">Preview</sl-button>
+    <sl-button variant="primary">Preview</sl-button>
   </div>
 </sl-card>
 


### PR DESCRIPTION
The button and div both had a slot equal to footer when only the footer div actually needs it.