### PR TITLE
Removed left border from button group

### DIFF
--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -558,7 +558,8 @@ export default css`
   }
 
   /* Add a visual separator between solid buttons */
-  :host(.sl-button-group__button:not(.sl-button-group__button--radio, [variant='default']):not(:hover)) .button:after {
+  :host(.sl-button-group__button:not(.sl-button-group__button--first, .sl-button-group__button--radio, [variant='default']):not(:hover))
+    .button:after {
     content: '';
     position: absolute;
     top: 0;


### PR DESCRIPTION
Fixes #974 
Actually fixes the bug I accidently caused in #980 (sorry for that).
For some reason I removed `.sl-button-group__button--first` from the css rule which still should be there. Therefore the first button also got a left border.
I hope this time everything works fine. 