### PR TITLE
Fix a bug of unexpected form submission with the Asian IMEs

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -316,7 +316,9 @@ export default class SlInput extends ShoelaceElement {
     // submitting to allow users to cancel the keydown event if they need to
     if (event.key === 'Enter' && !hasModifier) {
       setTimeout(() => {
-        if (!event.defaultPrevented) {
+        // isComposing is true when enter key is pressed while choosing the chinese/japanese/etc character
+        // so this check will prevent form submitting after choosing character by enter key pressing
+        if (!event.defaultPrevented && !event.isComposing) {
           this.formSubmitController.submit();
         }
       });


### PR DESCRIPTION
add check to input component if Japanese character is chosen by pressing enter key and prevent form submitting