### PR TITLE
Add `<sl-autocomplete>` component

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -24,6 +24,7 @@
 - Components
 
   - [Alert](/components/alert)
+  - [Autocomplete](/components/autocomplete)
   - [Avatar](/components/avatar)
   - [Badge](/components/badge)
   - [Breadcrumb](/components/breadcrumb)

--- a/docs/components/autocomplete.md
+++ b/docs/components/autocomplete.md
@@ -1,0 +1,127 @@
+# Autocomplete
+
+[component-header:sl-autocomplete]
+
+```html preview
+<sl-autocomplete autofilter class="language-autocomplete">
+  <sl-input slot="trigger" class="language-input"></sl-input>
+
+  <sl-menu-item value="english">English</sl-menu-item>
+  <sl-menu-item value="mandarin">Mandarin</sl-menu-item>
+  <sl-menu-item value="hindi">Hindi</sl-menu-item>
+  <sl-menu-item value="spanish">Spanish</sl-menu-item>
+  <sl-menu-item value="french">French</sl-menu-item>
+</sl-autocomplete>
+
+<script>
+  const autocomplete = document.querySelector('.language-autocomplete');
+  const input = document.querySelector('.language-input');
+
+  autocomplete.addEventListener('sl-select', event => {
+    input.value = event.detail.item.textContent;
+  });
+</script>
+```
+
+```jsx react
+// WIP...
+```
+
+## Examples
+
+### Async
+
+```html preview
+<sl-autocomplete class="async-autocomplete">
+  <sl-input slot="trigger" class="async-input"></sl-input>
+</sl-autocomplete>
+
+<script>
+  const autocomplete = document.querySelector('.async-autocomplete');
+  const input = document.querySelector('.async-input');
+
+  input.addEventListener('sl-input', event => {
+    autocomplete.loading = true;
+
+    setTimeout(() => {
+      const menuItemTags = ['English', 'Mandarin', 'Spanish']
+        .filter(option => new RegExp(event.target.value, 'ig').test(option))
+        .map(option => `<sl-menu-item value="${option}">${option}</sl-menu-item>`)
+        .join('');
+
+      autocomplete.querySelectorAll('sl-menu-item').forEach(el => el.remove());
+      autocomplete.insertAdjacentHTML('beforeend', menuItemTags);
+      autocomplete.loading = false;
+    }, 1000);
+  });
+
+  autocomplete.addEventListener('sl-select', event => {
+    input.value = event.detail.item.textContent;
+  });
+</script>
+```
+
+```jsx react
+// WIP...
+```
+
+### Loading State
+
+```html preview
+<sl-autocomplete class="loading-autocomplete">
+  <sl-input slot="trigger" class="loading-input"></sl-input>
+
+  <div slot="loading-text" style="margin: 1rem;">
+    <sl-skeleton effect="pulse"></sl-skeleton>
+    <sl-skeleton effect="pulse"></sl-skeleton>
+    <sl-skeleton effect="pulse"></sl-skeleton>
+  </div>
+</sl-autocomplete>
+
+<script>
+  const autocomplete = document.querySelector('.loading-autocomplete');
+  const input = document.querySelector('.loading-input');
+
+  input.addEventListener('sl-input', event => {
+    autocomplete.loading = true;
+
+    setTimeout(() => {
+      const menuItemTags = ['English', 'Mandarin', 'Spanish']
+        .map(option => `<sl-menu-item value="${option}">${option}</sl-menu-item>`)
+        .join('');
+
+      autocomplete.querySelectorAll('sl-menu-item').forEach(el => el.remove());
+      autocomplete.insertAdjacentHTML('beforeend', menuItemTags);
+      autocomplete.loading = false;
+    }, 1000);
+  });
+
+  autocomplete.addEventListener('sl-select', event => {
+    input.value = event.detail.item.textContent;
+  });
+</script>
+
+<style>
+  sl-autocomplete sl-skeleton:not(:first-child) {
+    margin-top: 1rem;
+  }
+</style>
+```
+
+### Empty State
+
+```html preview
+<sl-autocomplete autofilter>
+  <sl-input slot="trigger""></sl-input>
+
+  <sl-menu-item value="option-1">Option 1</sl-menu-item>
+  <sl-menu-item value="option-2">Option 2</sl-menu-item>
+  <sl-menu-item value="option-3">Option 3</sl-menu-item>
+
+  <div slot="empty-text" style="text-align: center; margin: var(--sl-spacing-small); color: var(--sl-color-neutral-500);">
+    We could not find any matches. Please try again.
+  </div>
+</sl-autocomplete>
+```
+
+[component-metadata:sl-autocomplete]

--- a/src/components/autocomplete/autocomplete.styles.ts
+++ b/src/components/autocomplete/autocomplete.styles.ts
@@ -1,0 +1,23 @@
+import { css } from 'lit';
+import componentStyles from '../../styles/component.styles';
+import formControlStyles from '../../styles/form-control.styles';
+
+export default css`
+  ${componentStyles}
+  ${formControlStyles}
+
+  :host {
+    display: inline-block;
+    width: 100%;
+  }
+
+  sl-dropdown {
+    display: block;
+    width: 100%;
+  }
+
+  sl-dropdown::part(panel) {
+    display: block;
+    width: 100%;
+  }
+`;

--- a/src/components/autocomplete/autocomplete.ts
+++ b/src/components/autocomplete/autocomplete.ts
@@ -1,0 +1,229 @@
+import { html, LitElement } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { styleMap } from 'lit/directives/style-map.js';
+import { HasSlotController } from '../../internal/slot';
+import '../dropdown/dropdown';
+import '../menu-item/menu-item';
+import '../menu/menu';
+import styles from './autocomplete.styles';
+import type SlDropdown from '../dropdown/dropdown';
+import type SlInput from '../input/input';
+import type SlMenuItem from '../menu-item/menu-item';
+import type SlMenu from '../menu/menu';
+import type { CSSResultGroup } from 'lit';
+
+const escapeRegExp = (text: string) => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+
+/**
+ * @summary Autocompletes displays suggestions as you type.
+ *
+ * @since unreleased
+ * @status unknown
+ *
+ * @dependency sl-dropdown
+ * @dependency sl-menu
+ *
+ * @slot - The content that includes an input.
+ * @slot empty-text - The text or content that is displayed when there is no suggestion based on the input.
+ * @slot lading-text - The text or content that is displayed when the `loading` attribute evaluates to true.
+ *
+ * @csspart base - The component's internal wrapper.
+ * @csspart trigger - The wrapper for the trigger slot.
+ * @csspart empty-text - The empty text's wrapper.
+ * @csspart loading-test - The loading text's wrapper.
+ *
+ */
+
+@customElement('sl-autocomplete')
+export default class SlAutocomplete extends LitElement {
+  static styles: CSSResultGroup = styles;
+
+  @query('sl-menu') menu: SlMenu;
+  @query('sl-dropdown') dropdown: SlDropdown;
+  @query('slot:not([name])') defaultSlot: HTMLSlotElement;
+
+  private readonly hasSlotController = new HasSlotController(this, 'loading-text', 'empty-text');
+
+  @state() private value = '';
+  @state() private hasFocus = false;
+
+  @property({ type: String, reflect: true }) emptyText: string;
+
+  @property({ type: Boolean, reflect: true }) loading = false;
+
+  @property({ type: String, reflect: true }) loadingText: string;
+
+  @property({ type: Boolean, reflect: true }) autofilter = false;
+
+  @property({ type: Boolean, reflect: true }) highlight = false;
+
+  @property({ type: Number, reflect: true }) threshold = 1;
+
+  handleSlInput(event: CustomEvent) {
+    const { value } = event.target as SlInput;
+
+    if (this.autofilter) {
+      this.options.forEach(option => {
+        const shouldDisplay = new RegExp(`(${escapeRegExp(value ?? '')})`, 'ig').test(option.getTextLabel());
+
+        if (shouldDisplay) {
+          option.style.display = 'block';
+          option.disabled = false;
+          option.ariaHidden = 'false';
+        } else {
+          option.style.display = 'none';
+          option.disabled = true;
+          option.ariaHidden = 'true';
+        }
+      });
+    }
+
+    this.hasFocus = true;
+    this.value = value;
+  }
+
+  handleKeydown(event: KeyboardEvent) {
+    if (!this.shouldDisplayAutoComplete || event.ctrlKey || event.metaKey) {
+      return;
+    }
+
+    const options = this.visibleOptions;
+
+    if (options.length === 0) {
+      return;
+    }
+
+    const firstItem = options[0];
+    const lastItem = options[options.length - 1];
+
+    switch (event.key) {
+      case 'Tab':
+      case 'Escape':
+        this.hasFocus = false;
+        break;
+
+      case 'ArrowDown':
+        event.preventDefault();
+        this.menu.setCurrentItem(firstItem);
+        firstItem.focus();
+        break;
+
+      case 'ArrowUp':
+        event.preventDefault();
+        this.menu.setCurrentItem(lastItem);
+        lastItem.focus();
+        break;
+    }
+  }
+
+  handleSlFocus() {
+    if (this.value.length >= this.threshold) {
+      this.hasFocus = true;
+      this.show();
+    }
+  }
+
+  handleSlAfterHide() {
+    this.hasFocus = false;
+  }
+
+  show() {
+    this.dropdown?.show();
+  }
+
+  hide() {
+    this.dropdown?.hide();
+  }
+
+  reset() {
+    this.value = '';
+  }
+
+  get options(): SlMenuItem[] {
+    return (this.defaultSlot?.assignedElements() || []) as SlMenuItem[];
+  }
+
+  get visibleOptions() {
+    return this.options.filter(option => option.style.display !== 'none');
+  }
+
+  get hasResults() {
+    return this.visibleOptions.length > 0;
+  }
+
+  get shouldDisplayLoadingText() {
+    return this.loading && (this.loadingText || this.hasSlotController.test('loading-text'));
+  }
+
+  get shouldDisplayEmptyText() {
+    return (
+      !this.shouldDisplayLoadingText &&
+      !this.hasResults &&
+      (this.emptyText || this.hasSlotController.test('empty-text'))
+    );
+  }
+
+  get shouldDisplayAutoComplete() {
+    return (
+      this.hasFocus &&
+      ((this.value.length >= this.threshold && this.hasResults) ||
+        this.shouldDisplayLoadingText ||
+        this.shouldDisplayEmptyText)
+    );
+  }
+
+  render() {
+    const { shouldDisplayLoadingText } = this;
+
+    return html`
+      <div part="base">
+        <div
+          part="trigger"
+          @sl-focus=${this.handleSlFocus}
+          @sl-input=${this.handleSlInput}
+          @keydown=${this.handleKeydown}
+        >
+          <slot name="trigger"></slot>
+        </div>
+
+        <sl-dropdown ?open=${this.shouldDisplayAutoComplete} @sl-after-hide=${this.handleSlAfterHide}>
+          <sl-menu>
+            <slot
+              aria-hidden=${shouldDisplayLoadingText ? 'true' : 'false'}
+              style="${styleMap({ display: shouldDisplayLoadingText ? 'none' : 'block' })}"
+            >
+            </slot>
+
+            <div
+              part="loading-text"
+              id="loading-text"
+              class="loading-text"
+              aria-hidden=${shouldDisplayLoadingText ? 'false' : 'true'}
+              style="${styleMap({ display: shouldDisplayLoadingText ? 'block' : 'none' })}"
+            >
+              <slot name="loading-text">${this.loadingText}</slot>
+            </div>
+
+            <div
+              part="empty-text"
+              id="empty-text"
+              class="empty-text"
+              aria-hidden=${this.shouldDisplayEmptyText ? 'false' : 'true'}
+              style="${styleMap({ display: this.shouldDisplayEmptyText ? 'block' : 'none' })}"
+            >
+              <slot name="empty-text">${this.emptyText}</slot>
+            </div>
+
+            <div aria-hidden="true" style=${styleMap({ width: `${this.clientWidth}px` })}></div>
+          </sl-menu>
+        </sl-dropdown>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sl-autocomplete': SlAutocomplete;
+  }
+}

--- a/src/shoelace.ts
+++ b/src/shoelace.ts
@@ -1,5 +1,6 @@
 // Components
 export { default as SlAlert } from './components/alert/alert';
+export { default as SlAutocomplete } from './components/autocomplete/autocomplete';
 export { default as SlAnimatedImage } from './components/animated-image/animated-image';
 export { default as SlAnimation } from './components/animation/animation';
 export { default as SlAvatar } from './components/avatar/avatar';


### PR DESCRIPTION
This adds a new component `<sl-autocomplete>`, which addresses https://github.com/shoelace-style/shoelace/issues/127. I know there is a lot of conversations and opinions going on here but I just wanted to show what I have now to get feedback. Most importantly, the accessibility support is not in the best shape yet. I was able to fix it on one of my apps (see below) by properly setting `listbox` and `option` roles to appropriate elements, but it required a bit hacky change in shoelace itself:

<img width="1101" alt="Screenshot 2022-11-09 at 10 26 46 PM" src="https://user-images.githubusercontent.com/386234/200852704-0f7b383c-ee73-4376-94cb-f36fbe281850.png">

(Well, not quite there yet as it says "selected" even though the option is not selected)

Ultimately we will have to wait until the `<sl-select>` is refactored and that should solve the accessibility issue with this component altogether. Perhaps we could add something like `<sl-option>` so we can distinguish menu items and options.

Here is a quick recording:

https://user-images.githubusercontent.com/386234/200851654-cc08d924-4f2e-4ff2-bbdf-7da01e182c47.mov




I would love any feedback. Thank you!

## Remaining Todos

 * [ ] Better accessibility support
 * [ ] Add more test coverage
 * [ ] Add more documentation