### PR TITLE
add "exports" field to support newer module resolutions like node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
   "web-types": "dist/web-types.json",
   "type": "module",
   "types": "dist/shoelace.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/shoelace.d.ts",
+      "import": "./dist/shoelace.js"
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Setting the `moduleResolution` in the tsconfig to node16 results in no types being resolved. 

I suppose the reason is a lacking `exports` field in `package.json`. See https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#packagejson-exports-imports-and-self-referencing. I haven't tested it but expect the exports field to solve the bug + it's a good idea anyways. 

**With node16 module resolution (the new module resolution)**
<img width="589" alt="image" src="https://user-images.githubusercontent.com/35429197/201970824-789e4f37-c9f7-4e0c-9b71-e78abb65ac70.png">

**With nodenext module resolution (the default)**

<img width="564" alt="image" src="https://user-images.githubusercontent.com/35429197/201971065-90d421f0-03e8-42de-b83a-6da41eab65e0.png">

Here is a reproduction https://stackblitz.com/edit/typescript-3exolv?file=index.ts