### PR TITLE
Added stepUp, stepDown and showPicker functions

### DIFF
--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -22,6 +22,8 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 - Added `--sl-input-required-content-color` custom property to all form controls [#948](https://github.com/shoelace-style/shoelace/pull/948)
 - Added the ability to cancel `sl-show` and `sl-hide` events in `<sl-details>` [#993](https://github.com/shoelace-style/shoelace/issues/993)
 - Added `focus()` and `blur()` methods to `<sl-radio-button>`
+- Added `stepUp()` and `stepDown()` methods to `<sl-input>` and `<sl-range>` [#1013](https://github.com/shoelace-style/shoelace/pull/1013)
+- Added `showPicker()` method to `<sl-input>` [#1013](https://github.com/shoelace-style/shoelace/pull/1013)
 - Added the `handle-icon` part to `<sl-image-comparer>`
 - Added `caret`, `check`, `grip-vertical`, `indeterminate`, and `radio` icons to the system library and removed `check-lg` [#985](https://github.com/shoelace-style/shoelace/issues/985)
 - Added the `loading` attribute to `<sl-avatar>` to allow lazy loading of image avatars [#1006](https://github.com/shoelace-style/shoelace/pull/1006)

--- a/src/components/input/input.test.ts
+++ b/src/components/input/input.test.ts
@@ -26,7 +26,7 @@ describe('<sl-input>', () => {
     expect(el.passwordToggle).to.be.false;
     expect(el.passwordVisible).to.be.false;
     expect(el.noSpinButtons).to.be.false;
-    expect(el.placeholder).to.be.undefined;
+    expect(el.placeholder).to.equal('');
     expect(el.disabled).to.be.false;
     expect(el.readonly).to.be.false;
     expect(el.minlength).to.be.undefined;

--- a/src/components/input/input.test.ts
+++ b/src/components/input/input.test.ts
@@ -10,6 +10,43 @@ describe('<sl-input>', () => {
     await expect(el).to.be.accessible();
   });
 
+  it('default properties', async () => {
+    const el = await fixture<SlInput>(html` <sl-input></sl-input> `);
+
+    expect(el.type).to.equal('text');
+    expect(el.size).to.equal('medium');
+    expect(el.name).to.equal('');
+    expect(el.value).to.equal('');
+    expect(el.defaultValue).to.equal('');
+    expect(el.filled).to.be.false;
+    expect(el.pill).to.be.false;
+    expect(el.label).to.equal('');
+    expect(el.helpText).to.equal('');
+    expect(el.clearable).to.be.false;
+    expect(el.passwordToggle).to.be.false;
+    expect(el.passwordVisible).to.be.false;
+    expect(el.noSpinButtons).to.be.false;
+    expect(el.placeholder).to.be.undefined;
+    expect(el.disabled).to.be.false;
+    expect(el.readonly).to.be.false;
+    expect(el.minlength).to.be.undefined;
+    expect(el.maxlength).to.be.undefined;
+    expect(el.min).to.be.undefined;
+    expect(el.max).to.be.undefined;
+    expect(el.step).to.be.undefined;
+    expect(el.pattern).to.be.undefined;
+    expect(el.required).to.be.false;
+    expect(el.autocapitalize).to.be.undefined;
+    expect(el.autocorrect).to.be.undefined;
+    expect(el.autocomplete).to.be.undefined;
+    expect(el.autofocus).to.be.undefined;
+    expect(el.enterkeyhint).to.be.undefined;
+    expect(el.spellcheck).to.be.undefined;
+    expect(el.inputmode).to.be.undefined;
+    expect(el.valueAsDate).to.be.null;
+    expect(isNaN(el.valueAsNumber)).to.be.true;
+  });
+
   it('should be disabled with the disabled attribute', async () => {
     const el = await fixture<SlInput>(html` <sl-input disabled></sl-input> `);
     const input = el.shadowRoot!.querySelector<HTMLInputElement>('[part="input"]')!;
@@ -207,6 +244,53 @@ describe('<sl-input>', () => {
       el.step = 1;
       await el.updateComplete;
       expect(el.invalid).to.be.true;
+    });
+
+    it('should increment by step if stepUp() is called', async () => {
+      const el = await fixture<SlInput>(html` <sl-input type="number" step="2" value="2"></sl-input> `);
+
+      el.stepUp();
+      await el.updateComplete;
+      expect(el.value).to.equal('4');
+    });
+
+    it('should decrement by step if stepDown() is called', async () => {
+      const el = await fixture<SlInput>(html` <sl-input type="number" step="2" value="2"></sl-input> `);
+
+      el.stepDown();
+      await el.updateComplete;
+      expect(el.value).to.equal('0');
+    });
+
+    it('should fire sl-input and sl-change if stepUp() is called', async () => {
+      const el = await fixture<SlInput>(html` <sl-input type="number" step="2" value="2"></sl-input> `);
+
+      const inputHandler = sinon.spy();
+      const changeHandler = sinon.spy();
+      el.addEventListener('sl-input', inputHandler);
+      el.addEventListener('sl-change', changeHandler);
+
+      el.stepUp();
+
+      await waitUntil(() => inputHandler.calledOnce);
+      await waitUntil(() => changeHandler.calledOnce);
+      expect(inputHandler).to.have.been.calledOnce;
+      expect(changeHandler).to.have.been.calledOnce;
+    });
+
+    it('should fire sl-input and sl-change if stepDown() is called', async () => {
+      const el = await fixture<SlInput>(html` <sl-input type="number" step="2" value="2"></sl-input> `);
+
+      const inputHandler = sinon.spy();
+      const changeHandler = sinon.spy();
+      el.addEventListener('sl-input', inputHandler);
+      el.addEventListener('sl-change', changeHandler);
+
+      el.stepUp();
+
+      await waitUntil(() => inputHandler.calledOnce);
+      await waitUntil(() => changeHandler.calledOnce);
+      expect(changeHandler).to.have.been.calledOnce;
     });
   });
 });

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -86,7 +86,7 @@ export default class SlInput extends ShoelaceElement {
   @property({ reflect: true }) size: 'small' | 'medium' | 'large' = 'medium';
 
   /** The input's name attribute. */
-  @property() name: string;
+  @property() name = '';
 
   /** The input's value attribute. */
   @property() value = '';
@@ -245,6 +245,33 @@ export default class SlInput extends ShoelaceElement {
   ) {
     this.input.setRangeText(replacement, start, end, selectMode);
 
+    if (this.value !== this.input.value) {
+      this.value = this.input.value;
+      this.emit('sl-input');
+      this.emit('sl-change');
+    }
+  }
+
+  /** Displays the browser picker for an input element (only works if the browser supports it for the input type). */
+  showPicker() {
+    if ('showPicker' in HTMLInputElement.prototype) {
+      this.input.showPicker();
+    }
+  }
+
+  /** Increments the value of a numeric input type by the value of the step attribute. */
+  stepUp() {
+    this.input.stepUp();
+    if (this.value !== this.input.value) {
+      this.value = this.input.value;
+      this.emit('sl-input');
+      this.emit('sl-change');
+    }
+  }
+
+  /** Decrements the value of a numeric input type by the value of the step attribute. */
+  stepDown() {
+    this.input.stepDown();
     if (this.value !== this.input.value) {
       this.value = this.input.value;
       this.emit('sl-input');

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -120,7 +120,7 @@ export default class SlInput extends ShoelaceElement {
   @property({ attribute: 'no-spin-buttons', type: Boolean }) noSpinButtons = false;
 
   /** The input's placeholder text. */
-  @property() placeholder: string;
+  @property() placeholder = '';
 
   /** Disables the input. */
   @property({ type: Boolean, reflect: true }) disabled = false;

--- a/src/components/range/range.test.ts
+++ b/src/components/range/range.test.ts
@@ -1,4 +1,5 @@
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
 import { serialize } from '../../utilities/form';
 import type SlRange from './range';
 
@@ -8,11 +9,65 @@ describe('<sl-range>', () => {
     await expect(el).to.be.accessible();
   });
 
+  it('default properties', async () => {
+    const el = await fixture<SlRange>(html` <sl-range></sl-range> `);
+
+    expect(el.name).to.equal('');
+    expect(el.value).to.equal(0);
+    expect(el.label).to.equal('');
+    expect(el.helpText).to.equal('');
+    expect(el.disabled).to.be.false;
+    expect(el.invalid).to.be.false;
+    expect(el.min).to.equal(0);
+    expect(el.max).to.equal(100);
+    expect(el.step).to.equal(1);
+    expect(el.tooltip).to.equal('top');
+    expect(el.defaultValue).to.equal(0);
+  });
+
   it('should be disabled with the disabled attribute', async () => {
     const el = await fixture<SlRange>(html` <sl-range disabled></sl-range> `);
     const input = el.shadowRoot!.querySelector<HTMLInputElement>('[part="input"]')!;
 
     expect(input.disabled).to.be.true;
+  });
+
+  describe('step', () => {
+    it('should increment by step if stepUp() is called', async () => {
+      const el = await fixture<SlRange>(html` <sl-range step="2" value="2"></sl-range> `);
+
+      el.stepUp();
+      await el.updateComplete;
+      expect(el.value).to.equal(4);
+    });
+
+    it('should decrement by step if stepDown() is called', async () => {
+      const el = await fixture<SlRange>(html` <sl-range step="2" value="2"></sl-range> `);
+
+      el.stepDown();
+      await el.updateComplete;
+      expect(el.value).to.equal(0);
+    });
+
+    it('should fire sl-change if stepUp() is called', async () => {
+      const el = await fixture<SlRange>(html` <sl-range step="2" value="2"></sl-range> `);
+
+      const changeHandler = sinon.spy();
+      el.addEventListener('sl-change', changeHandler);
+      el.stepUp();
+      await waitUntil(() => changeHandler.calledOnce);
+      expect(changeHandler).to.have.been.calledOnce;
+    });
+
+    it('should fire sl-change if stepDown() is called', async () => {
+      const el = await fixture<SlRange>(html` <sl-range step="2" value="2"></sl-range> `);
+
+      const changeHandler = sinon.spy();
+      el.addEventListener('sl-change', changeHandler);
+      el.stepUp();
+      await waitUntil(() => changeHandler.calledOnce);
+      expect(changeHandler).to.have.been.calledOnce;
+    });
   });
 
   describe('when serializing', () => {

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -128,6 +128,24 @@ export default class SlRange extends ShoelaceElement {
     this.input.blur();
   }
 
+  /** Increments the value of the input by the value of the step attribute. */
+  stepUp() {
+    this.input.stepUp();
+    if (this.value !== Number(this.input.value)) {
+      this.value = Number(this.input.value);
+      this.emit('sl-change');
+    }
+  }
+
+  /** Decrements the value of the input by the value of the step attribute. */
+  stepDown() {
+    this.input.stepDown();
+    if (this.value !== Number(this.input.value)) {
+      this.value = Number(this.input.value);
+      this.emit('sl-change');
+    }
+  }
+
   /** Sets a custom validation message. If `message` is not empty, the field will be considered invalid. */
   setCustomValidity(message: string) {
     this.input.setCustomValidity(message);

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -49,7 +49,7 @@ export default class SlTextarea extends ShoelaceElement {
   @property({ reflect: true }) size: 'small' | 'medium' | 'large' = 'medium';
 
   /** The textarea's name attribute. */
-  @property() name: string;
+  @property() name = '';
 
   /** The textarea's value attribute. */
   @property() value = '';
@@ -64,7 +64,7 @@ export default class SlTextarea extends ShoelaceElement {
   @property({ attribute: 'help-text' }) helpText = '';
 
   /** The textarea's placeholder text. */
-  @property() placeholder: string;
+  @property() placeholder = '';
 
   /** The number of rows to display by default. */
   @property({ type: Number }) rows = 4;

--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -10,3 +10,7 @@ declare namespace Chai {
     accessible: (options?: Object) => PromiseLike<Assertion>;
   }
 }
+
+interface HTMLInputElement {
+  showPicker: () => void;
+}


### PR DESCRIPTION
Fixes #1008 
Hi, this PR adds:
-  `stepUp()`, `stepDown()` to `<sl-input>` and `<sl-range>`
- `showPicker()` to `<sl-input>`
- Tests for the new step functions
- Tests for default properties

TypeScript showed up an error for the `showPicker` function call on the input. Due to the [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker) it actually exists nowadays in every browser but I thought adding a check can't break something so I've added one. Because the error still occured I've added it to the `declaration.d.ts`. Alternatively the TypeScript could be disabled for the line.

Also while writing the tests for the default properties I noticed that `<sl-input>` and `<sl-textarea>` doesn't set the `name` and `placeholder` to an empty string like other components (`<sl-select>`, `<sl-radio-group>`, `<sl-range>`) so I've changed that too.