### PR TITLE
fix isTreeItem method when called with non-element nodes

### DIFF
--- a/src/components/tree-item/tree-item.ts
+++ b/src/components/tree-item/tree-item.ts
@@ -14,8 +14,8 @@ import '../spinner/spinner';
 import styles from './tree-item.styles';
 import type { CSSResultGroup, PropertyValueMap } from 'lit';
 
-export function isTreeItem(element: Element) {
-  return element && element?.getAttribute('role') === 'treeitem';
+export function isTreeItem(node: Node) {
+  return node instanceof Element && node.getAttribute('role') === 'treeitem';
 }
 
 /**


### PR DESCRIPTION
Fixes #1025 

The `isTreeItem` method was wrongly typed as accepting `Element` instances but gets called on `Node`s in `SlTree`'s `handleTreeChanged` and these `Node`s can also be non-elements without `getAttribute` method.

A more underlying problem is the `tsconfig` setting `strictFunctionTypes` set to `false`. If it had been `true` TS would have caught the calls to `isTreeItem` where it is passed any `Node`.