### PR TITLE
only emit tree selection change event when selection has changed

### DIFF
--- a/src/components/tree/tree.ts
+++ b/src/components/tree/tree.ts
@@ -177,6 +177,8 @@ export default class SlTree extends ShoelaceElement {
   }
 
   selectItem(selectedItem: SlTreeItem) {
+    const previousSelection = [...this.selectedItems];
+
     if (this.selection === 'multiple') {
       selectedItem.selected = !selectedItem.selected;
       if (selectedItem.lazy) {
@@ -192,7 +194,11 @@ export default class SlTree extends ShoelaceElement {
       selectedItem.expanded = !selectedItem.expanded;
     }
 
-    this.emit('sl-selection-change', { detail: { selection: this.selectedItems } });
+    const nextSelection = this.selectedItems;
+
+    if (nextSelection.some(item => !previousSelection.includes(item))) {
+      this.emit('sl-selection-change', { detail: { selection: nextSelection } });
+    }
   }
 
   // Returns the list of tree items that are selected in the tree.


### PR DESCRIPTION
Fixes #1029 

This adds a check before the `sl-selection-change` event is emitted, comparing the selection before and after syncing and only issues the emit when the selection actually did change.