### PR TITLE
Update `make-react.js` script to use new @lit-labs/react createComponent options object

### DIFF
--- a/scripts/make-react.js
+++ b/scripts/make-react.js
@@ -3,7 +3,6 @@ import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import { deleteSync } from 'del';
-import { pascalCase } from 'pascal-case';
 import prettier from 'prettier';
 import prettierConfig from '../prettier.config.cjs';
 import { getAllComponents } from './shared.js';

--- a/scripts/make-react.js
+++ b/scripts/make-react.js
@@ -40,14 +40,14 @@ components.map(component => {
       import { createComponent } from '@lit-labs/react';
       import Component from '../../${importPath}';
 
-      export default createComponent(
-        React,
-        '${component.tagName}',
-        Component,
-        {
+      export default createComponent({
+        tagName: '${component.tagName}',
+        elementClass: Component,
+        react: React,
+        events: {
           ${events}
         }
-      );
+      });
     `,
     Object.assign(prettierConfig, {
       parser: 'babel-ts'


### PR DESCRIPTION
`@lit-labs/react` `createComponent` wrapper [introduced an options object](https://github.com/lit/lit/pull/2988) in [1.1.0](https://github.com/lit/lit/releases/tag/%40lit-labs%2Freact%401.1.0) (the old way still works but is currently marked as [deprecated](https://github.com/lit/lit/blob/main/packages/labs/react/src/create-component.ts#L189-L211)).

The new approach is documented in the [readme](https://github.com/lit/lit/tree/main/packages/labs/react) and looks like this:

```typescript
import * as React from 'react';
import {createComponent} from '@lit-labs/react';
import {MyElement} from './my-element.js';

export const MyElementComponent = createComponent({
  tagName: 'my-element',
  elementClass: MyElement,
  react: React,
  events: {
    onactivate: 'activate',
    onchange: 'change',
  },
});
```

This adjusts the `make-react.js` script to use the newer approach, also removed unused `pascal-case` import.