### PR TITLE
Add raw icons to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "./dist/utilities/*": "./dist/utilities/*",
     "./dist/react": "./dist/react/index.js",
     "./dist/react/*": "./dist/react/*",
-    "./dist/translations/*": "./dist/translations/*"
+    "./dist/translations/*": "./dist/translations/*",
+    "./dist/assets/icons/*": "./dist/assets/icons/*"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Closes #1094 : Adds the the raw icons directory (`dist/assets/icons`) to the package's exports.