### PR TITLE
fix #1101 - duplicate tests

### DIFF
--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -4,7 +4,6 @@ import { globbySync } from 'globby';
 
 export default {
   rootDir: '.',
-  files: 'src/**/*.test.ts',
   concurrentBrowsers: 3,
   nodeResolve: true,
   plugins: [


### PR DESCRIPTION
fixes: #1101
Tests are being duplicated because there are both `files` and `groups` options in the web-test-runner config. Note that both point to `src/**/*.test.ts`. Removing one of them (`files`) fixes the problem.