### PR TITLE
Add JSON format for design tokens

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -25,6 +25,8 @@ fs.mkdirSync(outdir, { recursive: true });
 
 (async () => {
   try {
+    execSync(`node scripts/tokens-to-css.js --theme light --outdir "${outdir}"`, { stdio: 'inherit' });
+    execSync(`node scripts/tokens-to-css.js --theme dark --outdir "${outdir}"`, { stdio: 'inherit' });
     execSync(`node scripts/make-metadata.js --outdir "${outdir}"`, { stdio: 'inherit' });
     execSync(`node scripts/make-search.js --outdir "${outdir}"`, { stdio: 'inherit' });
     execSync(`node scripts/make-react.js --outdir "${outdir}"`, { stdio: 'inherit' });

--- a/scripts/tokens-to-css.js
+++ b/scripts/tokens-to-css.js
@@ -1,24 +1,29 @@
 import fs from 'fs';
+import commandLineArgs from 'command-line-args';
 
-let source = fs.readFileSync('default.json', 'utf8');
-let tokens = JSON.parse(source);
+const { theme } = commandLineArgs({ name: 'theme', type: String, defaultValue: 'light' });
 
-let currentTheme = 'light';
-let rootSelectors = [':root', ':host', `.sl-theme-${currentTheme}`];
-let outputLines = [];
+const source = fs.readFileSync('src/themes/default.json', 'utf8');
+const tokens = JSON.parse(source);
 
-let processThemeValues = entries => {
+const rootSelectors = [':root'];
+if (theme == 'light') rootSelectors.push(':host');
+rootSelectors.push(`.sl-theme-${theme}`);
+
+const outputLines = [];
+
+const processThemeValues = entries => {
   entries.forEach(([key, value]) => {
     let suffixComment = '';
 
     if (value.newline) outputLines.push('');
     if (value.comment) suffixComment = ` /* ${value.comment} */`;
-    outputLines.push(`  --sl-${key}: ${value.themes[currentTheme] || value.themes['light']};${suffixComment}`);
+    outputLines.push(`  --sl-${key}: ${value.themes[theme] || value.themes['light']};${suffixComment}`);
   });
 };
 
 outputLines.push(`${rootSelectors.join(',\n')} {`);
-outputLines.push(`  color-scheme: ${currentTheme};`);
+outputLines.push(`  color-scheme: ${theme};`);
 
 Object.entries(tokens).forEach(([key, value]) => {
   outputLines.push(`\n  /*\n   * ${key}\n   */`);

--- a/src/themes/default.json
+++ b/src/themes/default.json
@@ -1,67 +1,58 @@
 {
   "Color Primitives": {
+    "$description": "Example description of colors",
     "Gray": {
+      "$description": "Gray colors",
       "color-gray-50": {
-        "themes": {
-          "light": "hsl(0 0% 97.5%)",
-          "dark": "hsl(240 5.1% 15%)"
+        "$value": "hsl(0 0% 97.5%)",
+        "$extensions": {
+          "style.shoelace.theme-dark": "hsl(240 5.1% 15%)"
         }
       },
       "color-gray-100": {
-        "themes": {
-          "light": "hsl(240 4.8% 95.9%)",
-          "dark": "hsl(240 5.7% 18.2%)"
+        "$value": "hsl(240 4.8% 95.9%)",
+        "$extensions": {
+          "style.shoelace.theme-dark": "hsl(240 5.7% 18.2%)"
         }
       }
     }
   },
   "Theme Tokens": {
+    "$description": "These are semantic colors",
     "Primary": {
       "color-primary-50": {
-        "themes": {
-          "light": "var(--sl-color-sky-50)",
-          "dark": "var(--sl-color-sky-50)"
-        }
+        "$value": "var(--sl-color-sky-50)"
       },
       "color-primary-100": {
-        "themes": {
-          "light": "var(--sl-color-sky-100)",
-          "dark": "var(--sl-color-sky-100)"
-        }
+        "$value": "var(--sl-color-sky-100)"
       }
     },
     "Warning": {
       "color-warning-50": {
-        "themes": {
-          "light": "var(--sl-color-amber-50)",
-          "dark": "var(--sl-color-amber-50)"
-        }
+        "$value": "var(--sl-color-amber-50)"
       },
       "color-warning-100": {
-        "themes": {
-          "light": "var(--sl-color-amber-100)",
-          "dark": "var(--sl-color-amber-100)"
-        }
+        "$value": "var(--sl-color-amber-100)"
       }
     }
   },
   "Border Radii": {
     "border-radius-small": {
-      "themes": {
-        "light": "0.1875rem"
-      },
-      "comment": "3px"
+      "$value": "0.1875rem",
+      "$extensions": {
+        "style.shoelace.comment": "3px"
+      }
     },
     "border-radius-medium": {
-      "themes": {
-        "light": "0.25rem"
-      },
-      "comment": "4px"
+      "$value": "0.25rem",
+      "$extensions": {
+        "style.shoelace.comment": "4px"
+      }
     },
     "border-radius-circle": {
-      "newline": true,
-      "themes": {
-        "light": "50%"
+      "$value": "50%",
+      "$extensions": {
+        "style.shoelace.newline": true
       }
     }
   }

--- a/src/themes/default.json
+++ b/src/themes/default.json
@@ -1,0 +1,68 @@
+{
+  "Color Primitives": {
+    "Gray": {
+      "color-gray-50": {
+        "themes": {
+          "light": "hsl(0 0% 97.5%)",
+          "dark": "hsl(240 5.1% 15%)"
+        }
+      },
+      "color-gray-100": {
+        "themes": {
+          "light": "hsl(240 4.8% 95.9%)",
+          "dark": "hsl(240 5.7% 18.2%)"
+        }
+      }
+    }
+  },
+  "Theme Tokens": {
+    "Primary": {
+      "color-primary-50": {
+        "themes": {
+          "light": "var(--sl-color-sky-50)",
+          "dark": "var(--sl-color-sky-50)"
+        }
+      },
+      "color-primary-100": {
+        "themes": {
+          "light": "var(--sl-color-sky-100)",
+          "dark": "var(--sl-color-sky-100)"
+        }
+      }
+    },
+    "Warning": {
+      "color-warning-50": {
+        "themes": {
+          "light": "var(--sl-color-amber-50)",
+          "dark": "var(--sl-color-amber-50)"
+        }
+      },
+      "color-warning-100": {
+        "themes": {
+          "light": "var(--sl-color-amber-100)",
+          "dark": "var(--sl-color-amber-100)"
+        }
+      }
+    }
+  },
+  "Border Radii": {
+    "border-radius-small": {
+      "themes": {
+        "light": "0.1875rem"
+      },
+      "comment": "3px"
+    },
+    "border-radius-medium": {
+      "themes": {
+        "light": "0.25rem"
+      },
+      "comment": "4px"
+    },
+    "border-radius-circle": {
+      "newline": true,
+      "themes": {
+        "light": "50%"
+      }
+    }
+  }
+}

--- a/src/themes/tokensToCSS.js
+++ b/src/themes/tokensToCSS.js
@@ -1,0 +1,41 @@
+import fs from 'fs';
+
+let source = fs.readFileSync('default.json', 'utf8');
+let tokens = JSON.parse(source);
+
+let currentTheme = 'light';
+let rootSelectors = [':root', ':host', `.sl-theme-${currentTheme}`];
+let outputLines = [];
+
+let processThemeValues = entries => {
+  entries.forEach(([key, value]) => {
+    let suffixComment = '';
+
+    if (value.newline) outputLines.push('');
+    if (value.comment) suffixComment = ` /* ${value.comment} */`;
+    outputLines.push(`  --sl-${key}: ${value.themes[currentTheme] || value.themes['light']};${suffixComment}`);
+  });
+};
+
+outputLines.push(`${rootSelectors.join(',\n')} {`);
+outputLines.push(`  color-scheme: ${currentTheme};`);
+
+Object.entries(tokens).forEach(([key, value]) => {
+  outputLines.push(`\n  /*\n   * ${key}\n   */`);
+
+  if (Object.keys(Object.entries(value)[0][1]).includes('themes')) {
+    // Shallow set of values
+    outputLines.push('');
+    processThemeValues(Object.entries(value));
+  } else {
+    // Nested sets of values
+    Object.entries(value).forEach(([subKey, subValue]) => {
+      outputLines.push(`\n  /* ${subKey} */`);
+      processThemeValues(Object.entries(subValue));
+    });
+  }
+});
+
+outputLines.push('}');
+
+console.log(outputLines.join('\n'));


### PR DESCRIPTION
Hey @claviska, as promised I've worked on a script to pull in design tokens saved in a JSON file which uses the [Design Tokens Community Group proposed format](https://design-tokens.github.io/community-group/format/), and then export those out to CSS files containing the variables. Should help in further work later on to address #1068, as well as make it much easier to keep shared tokens between light and dark themes in sync (and possibly additional themes later).

Right now it's exporting to `${outdir}/themes/generated` so as not to interfere with the current theme files, but that can be changed once all the tokens have been added to the JSON and the output is accurate.

Let me know if you have any questions!