### PR TITLE
Avoid null logs on resize observer errors

### DIFF
--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -30,6 +30,11 @@ export default {
       <body>
         <link rel="stylesheet" href="dist/themes/light.css">
         <script type="module" src="dist/shoelace.js"></script>
+        <script>window.addEventListener('error', e => {
+          if(!e.error && e.message && (e.message.includes('ResizeObserver') || e.message === 'Script error.')) {
+            e.stopImmediatePropagation();
+          }
+      });</script>
         <script type="module" src="${testFramework}"></script>
       </body>
     </html>


### PR DESCRIPTION
* Resize observer sometimes throws errors which are nothing to worry about, see also the corresponding comment on tab-group.test.ts
* Unfortunately, the web testing library installs an error event handler which takes precedence before the event handlers installed in the tests
(see node_modules/@web/browser-logs/dist/logUncaughtErrors.js)
* the only possibility to avoid these null logs is to install an error event handler at an even earlier place