### PR TITLE
fix(carousel): various fixes and improvements

### DIFF
--- a/src/components/carousel/autoplay-controller.ts
+++ b/src/components/carousel/autoplay-controller.ts
@@ -8,6 +8,7 @@ export class AutoplayController implements ReactiveController {
   private host: ReactiveElement;
   private timerId = 0;
   private tickCallback: () => void;
+  private activeInteractions = 0;
 
   paused = false;
   stopped = true;
@@ -57,12 +58,16 @@ export class AutoplayController implements ReactiveController {
   }
 
   pause = () => {
-    this.paused = true;
-    this.host.requestUpdate();
+    if (!this.activeInteractions++) {
+      this.paused = true;
+      this.host.requestUpdate();
+    }
   };
 
   resume = () => {
-    this.paused = false;
-    this.host.requestUpdate();
+    if (!--this.activeInteractions) {
+      this.paused = false;
+      this.host.requestUpdate();
+    }
   };
 }

--- a/src/components/carousel/carousel.styles.ts
+++ b/src/components/carousel/carousel.styles.ts
@@ -30,6 +30,7 @@ export default css`
     grid-area: pagination;
 
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
     gap: var(--sl-spacing-small);
   }

--- a/src/components/carousel/carousel.test.ts
+++ b/src/components/carousel/carousel.test.ts
@@ -78,6 +78,34 @@ describe('<sl-carousel>', () => {
       // Assert
       expect(el.next).not.to.have.been.called;
     });
+
+    it('should not resume if the user is still interacting', async () => {
+      // Arrange
+      const el = await fixture<SlCarousel>(html`
+        <sl-carousel autoplay autoplay-interval="10">
+          <sl-carousel-item>Node 1</sl-carousel-item>
+          <sl-carousel-item>Node 2</sl-carousel-item>
+          <sl-carousel-item>Node 3</sl-carousel-item>
+        </sl-carousel>
+      `);
+      sinon.stub(el, 'next');
+
+      await el.updateComplete;
+
+      // Act
+      el.dispatchEvent(new Event('mouseenter'));
+      el.dispatchEvent(new Event('focusin'));
+      await el.updateComplete;
+
+      el.dispatchEvent(new Event('mouseleave'));
+      await el.updateComplete;
+
+      clock.next();
+      clock.next();
+
+      // Assert
+      expect(el.next).not.to.have.been.called;
+    });
   });
 
   describe('when `loop` attribute is provided', () => {

--- a/src/components/carousel/scroll-controller.ts
+++ b/src/components/carousel/scroll-controller.ts
@@ -77,6 +77,8 @@ export class ScrollController<T extends ScrollHost> implements ReactiveControlle
         })
       );
       this.host.requestUpdate();
+    } else {
+      this.handleScrollEnd();
     }
   }
 


### PR DESCRIPTION
This PR includes some fixes reported in #1210
- Doesn't resume autoplay if user is still interacting (e.g. focus leaves but mouse still over)
- Wraps pagination dots when there are many of them
- Pagination dots are more reactive, they will update immediately when the user scrolls using controls (arrows, dots, keyboard, etc..).
- Fixes a bug where the scrollend event was not emitted in case the user scrolled exactly over a snap point (e.g. scroll until the end of the carousel)