### PR TITLE
Fix iOS overscroll in <sl-carousel>

### DIFF
--- a/src/components/carousel/carousel.styles.ts
+++ b/src/components/carousel/carousel.styles.ts
@@ -64,6 +64,7 @@ export default css`
     scroll-snap-type: x mandatory;
     scroll-padding-inline: var(--scroll-hint);
     padding-inline: var(--scroll-hint);
+    overflow-y: hidden;
   }
 
   .carousel__slides--vertical {
@@ -74,6 +75,7 @@ export default css`
     scroll-snap-type: y mandatory;
     scroll-padding-block: var(--scroll-hint);
     padding-block: var(--scroll-hint);
+    overflow-x: hidden;
   }
 
   .carousel__slides--dragging,


### PR DESCRIPTION
Improves iOS scrolling so horizontal carousels don't overscroll vertically and vertical carousels don't overscroll horizontally.

/cc @alenaksu This turned out to be a simple fix! 😅