### PR TITLE
Export autoload discover function and support shadow roots

### DIFF
--- a/src/shoelace-autoloader.ts
+++ b/src/shoelace-autoloader.ts
@@ -13,16 +13,16 @@ const observer = new MutationObserver(mutations => {
 /**
  * Checks a node for undefined elements and attempts to register them.
  */
-async function discover(root: Element) {
-  const rootTagName = root.tagName.toLowerCase();
-  const rootIsCustomElement = rootTagName.includes('-');
+ export async function discover(root: Element | ShadowRoot) {
+  const rootTagName = root instanceof Element ? root.tagName.toLowerCase() : "";
+  const rootIsCustomElement = rootTagName?.includes('-');
   const tags = [...root.querySelectorAll(':not(:defined)')]
     .map(el => el.tagName.toLowerCase())
     .filter(tag => tag.startsWith('sl-'));
 
   // If the root element is an undefined custom element, add it to the list
   if (rootIsCustomElement && !customElements.get(rootTagName)) {
-    tags.push(root.tagName.toLowerCase());
+    tags.push(rootTagName);
   }
 
   // Make the list unique

--- a/src/shoelace-autoloader.ts
+++ b/src/shoelace-autoloader.ts
@@ -13,8 +13,8 @@ const observer = new MutationObserver(mutations => {
 /**
  * Checks a node for undefined elements and attempts to register them.
  */
- export async function discover(root: Element | ShadowRoot) {
-  const rootTagName = root instanceof Element ? root.tagName.toLowerCase() : "";
+export async function discover(root: Element | ShadowRoot) {
+  const rootTagName = root instanceof Element ? root.tagName.toLowerCase() : '';
   const rootIsCustomElement = rootTagName?.includes('-');
   const tags = [...root.querySelectorAll(':not(:defined)')]
     .map(el => el.tagName.toLowerCase())


### PR DESCRIPTION
This allows for a `discover(this.shadowRoot)` call within a consumer's web component to opt-into autoloading. Otherwise, if someone has built a component which includes a Shoelace component in the component's shadow DOM, autoloading won't work.

(Note: this doesn't add a mutation observer, so it's a one-time discovery. Most component shadow trees are pretty stable I imagine, so I think that's fine, but if it feels too much like a potential gotcha, we could consider opting-in to a mutation observer for the tree.)