### PR TITLE
fix(tree-item): move label outside of checkbox

### DIFF
--- a/src/components/tree-item/tree-item.ts
+++ b/src/components/tree-item/tree-item.ts
@@ -263,12 +263,11 @@ export default class SlTreeItem extends ShoelaceElement {
                   ?disabled="${this.disabled}"
                   ?checked="${live(this.selected)}"
                   ?indeterminate="${this.indeterminate}"
-                >
-                  <slot class="tree-item__label" part="label"></slot>
-                </sl-checkbox>
-              `,
-            () => html` <slot class="tree-item__label" part="label"></slot> `
+                ></sl-checkbox>
+              `
           )}
+
+          <slot class="tree-item__label" part="label"></slot>
         </div>
 
         <slot


### PR DESCRIPTION
The PR contains a quick and easy fix to allow people to use elements that can be interacted with. However, it would be necessary to stop the propagation of the event in some cases.

example:
```html
<sl-tree selection="multiple">
  <sl-tree-item>
    <sl-button class="test">Button</sl-button> Test
    <sl-tree-item>Field maple</sl-tree-item>
    <sl-tree-item>Red maple</sl-tree-item>
    <sl-tree-item>Sugar maple</sl-tree-item>
  </sl-tree-item>
</sl-tree>
<script>
  customElements.whenDefined('sl-tree').then(async () => {
    const tree = document.querySelector('sl-tree');
    await tree.updateComplete;

    document.querySelector('.test').addEventListener('click', e => {
      e.stopPropagation();
      alert('click');
    }, true);
  });
</script>
```
fixes #1234 
