### PR TITLE
Memory leaks hunting

### DIFF
--- a/src/internal/form.ts
+++ b/src/internal/form.ts
@@ -19,7 +19,7 @@ const reportValidityOverloads: WeakMap<HTMLFormElement, () => boolean> = new Wea
 // We store a Set of controls that users have interacted with. This allows us to determine the interaction state
 // without littering the DOM with additional data attributes.
 //
-const userInteractedControls: Set<ShoelaceFormControl> = new Set();
+const userInteractedControls: WeakSet<ShoelaceFormControl> = new WeakSet();
 
 //
 // We store a WeakMap of interactions for each form control so we can track when all conditions are met for validation.


### PR DESCRIPTION
Hello,

I use Shoelace in a dynamic JS environment where nodes are added / removed from the DOM fairly frequently.

There are two places where I saw memory being retained by Shoelace. One in a Set that could be a WeakSet instead (easy win there,) but another one in the `includeFiles` Map for request caching.

It would seem that keeping the Promise object can cause previously resolved elements to be retained. I am not sure how Promise are handled internally (at least in Chrome,) but removing the Promise altogether and keeping the object seems to alleviate significanlty the load on memory.
