### PR TITLE
allow for sl-input to be inside button groups

### DIFF
--- a/docs/frameworks/angular.md
+++ b/docs/frameworks/angular.md
@@ -60,12 +60,12 @@ export class DrawerExampleComponent implements OnInit {
 
   constructor(...) {
   }
-  
+
   ngOnInit() {
   }
 
   ...
-  
+
   showDrawer() {
     // use nativeElement to access Shoelace components
     this.drawer?.nativeElement.show();

--- a/src/components/button-group/button-group.styles.ts
+++ b/src/components/button-group/button-group.styles.ts
@@ -11,5 +11,6 @@ export default css`
   .button-group {
     display: flex;
     flex-wrap: nowrap;
+    width: 100%;
   }
 `;

--- a/src/components/button-group/button-group.ts
+++ b/src/components/button-group/button-group.ts
@@ -84,7 +84,7 @@ export default class SlButtonGroup extends ShoelaceElement {
 }
 
 function findButton(el: HTMLElement) {
-  const selector = 'sl-button, sl-radio-button';
+  const selector = 'sl-button, sl-radio-button, sl-input';
 
   // The button could be the target element or a child of it (e.g. a dropdown or tooltip anchor)
   return el.closest(selector) ?? el.querySelector(selector);

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -291,4 +291,43 @@ export default css`
   .input--no-spin-buttons input[type='number'] {
     -moz-appearance: textfield;
   }
+
+  /*
+   * Button groups support a variety of button types (e.g. buttons with tooltips, buttons as dropdown triggers, etc.).
+   * This means buttons aren't always direct descendants of the button group, thus we can't target them with the
+   * ::slotted selector. To work around this, the button group component does some magic to add these special classes to
+   * buttons and we style them here instead.
+   */
+
+  :host(.sl-button-group__button--first:not(.sl-button-group__button--last)) .input {
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
+
+  :host(.sl-button-group__button--inner) .input {
+    border-radius: 0;
+  }
+
+  :host(.sl-button-group__button--last:not(.sl-button-group__button--first)) .input {
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
+  }
+
+  /* All except the first */
+  :host(.sl-button-group__button:not(.sl-button-group__button--first)) {
+    margin-inline-start: calc(-1 * var(--sl-input-border-width));
+  }
+
+  /* Add a visual separator between solid buttons */
+
+  /* Bump hovered, focused, and checked buttons up so their focus ring isn't clipped */
+  :host(.sl-button-group__button--hover) {
+    z-index: 1;
+  }
+
+  /* Focus and checked are always on top */
+  :host(.sl-button-group__button--focus),
+  :host(.sl-button-group__button[checked]) {
+    z-index: 2;
+  }
 `;


### PR DESCRIPTION
Not sure if it was better to write up an issue first, but I thought that allowing sl-input to be inside sl-button-group looked nice.

If you like it, maybe sl-select and other controls (those that have a size attribute in general I suppose) could benefit from that ?

Or do you see an issue with the idea in general ?