### PR TITLE
stop holding a reference to a Promise when it is resolved

### DIFF
--- a/src/components/include/request.ts
+++ b/src/components/include/request.ts
@@ -4,20 +4,26 @@ interface IncludeFile {
   html: string;
 }
 
-const includeFiles = new Map<string, Promise<IncludeFile>>();
+const includeFiles = new Map<string, IncludeFile | Promise<IncludeFile>>();
 
 /** Fetches an include file from a remote source. Caching is enabled so the origin is only pinged once. */
 export function requestInclude(src: string, mode: 'cors' | 'no-cors' | 'same-origin' = 'cors'): Promise<IncludeFile> {
-  if (includeFiles.has(src)) {
-    return includeFiles.get(src)!;
+  const prev = includeFiles.get(src);
+  if (prev !== undefined) {
+    // Promise.resolve() transparently unboxes prev if it was a promise.
+    return Promise.resolve(prev);
   }
   const fileDataPromise = fetch(src, { mode: mode }).then(async response => {
-    return {
+    const res = {
       ok: response.ok,
       status: response.status,
       html: await response.text()
     };
+    // Replace the cached promise with its result to avoid having buggy browser Promises retain memory as mentioned in #1284 and #1249
+    includeFiles.set(src, res);
+    return res;
   });
+  // Cache the promise to only fetch() once per src
   includeFiles.set(src, fileDataPromise);
   return fileDataPromise;
 }


### PR DESCRIPTION
I'm coming back on this closed PR : https://astegmaier.github.io/cached-promise-memory-leak/index.html

I still observe memory leaks in my application due to the includeFile Map. It would seem there is some regression around Promises in Chrome at least.

Wouldn't it still be somewhat better to guard against this possibility by not holding the promise objects in the Map to be sure ?

This approach is a lot simpler (I forgot that `Promise.resolve()` actually unboxes Promises), maybe you would consider it mergeable ?