### PR TITLE
fix: split-panel divider now focusable in Edge / Chrome

### DIFF
--- a/src/components/split-panel/split-panel.ts
+++ b/src/components/split-panel/split-panel.ts
@@ -249,17 +249,23 @@ export default class SlSplitPanel extends ShoelaceElement {
     return html`
       <slot name="start" part="panel start" class="start"></slot>
 
-      <slot
-        name="divider"
+      <div
         part="divider"
         class="divider"
         tabindex=${ifDefined(this.disabled ? undefined : '0')}
         role="separator"
+        aria-valuenow=${this.position}
+        aria-valuemin="0"
+        aria-valuemax="100"
         aria-label=${this.localize.term('resize')}
         @keydown=${this.handleKeyDown}
         @mousedown=${this.handleDrag}
         @touchstart=${this.handleDrag}
-      ></slot>
+      >
+        <slot
+          name="divider"
+        ></slot>
+      </div>
 
       <slot name="end" part="panel end" class="end"></slot>
     `;


### PR DESCRIPTION
- split-panel divider focusable in Edge / Chrome
- Added aria-value{min,max,now} for the divider