### PR TITLE
Fixed extra empty attributes being added to some form elements (fixes #1281)

### DIFF
--- a/src/components/input/input.test.ts
+++ b/src/components/input/input.test.ts
@@ -18,7 +18,7 @@ describe('<sl-input>', () => {
 
     expect(el.type).to.equal('text');
     expect(el.size).to.equal('medium');
-    expect(el.name).to.equal('');
+    expect(el.name).to.be.undefined;
     expect(el.value).to.equal('');
     expect(el.defaultValue).to.equal('');
     expect(el.title).to.equal('');
@@ -30,7 +30,7 @@ describe('<sl-input>', () => {
     expect(el.passwordToggle).to.be.false;
     expect(el.passwordVisible).to.be.false;
     expect(el.noSpinButtons).to.be.false;
-    expect(el.placeholder).to.equal('');
+    expect(el.placeholder).to.be.undefined;
     expect(el.disabled).to.be.false;
     expect(el.readonly).to.be.false;
     expect(el.minlength).to.be.undefined;

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -80,7 +80,7 @@ export default class SlInput extends ShoelaceElement implements ShoelaceFormCont
     | 'url' = 'text';
 
   /** The name of the input, submitted as a name/value pair with form data. */
-  @property() name = '';
+  @property() name?: string;
 
   /** The current value of the input, submitted as a name/value pair with form data. */
   @property() value = '';
@@ -110,7 +110,7 @@ export default class SlInput extends ShoelaceElement implements ShoelaceFormCont
   @property({ type: Boolean, reflect: true }) disabled = false;
 
   /** Placeholder text to show as a hint when the input is empty. */
-  @property() placeholder = '';
+  @property() placeholder?: string;
 
   /** Makes the input readonly. */
   @property({ type: Boolean, reflect: true }) readonly = false;

--- a/src/components/range/range.test.ts
+++ b/src/components/range/range.test.ts
@@ -15,7 +15,7 @@ describe('<sl-range>', () => {
   it('default properties', async () => {
     const el = await fixture<SlRange>(html` <sl-range></sl-range> `);
 
-    expect(el.name).to.equal('');
+    expect(el.name).to.be.undefined;
     expect(el.value).to.equal(0);
     expect(el.title).to.equal('');
     expect(el.label).to.equal('');

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -60,7 +60,7 @@ export default class SlRange extends ShoelaceElement implements ShoelaceFormCont
   @property() title = ''; // make reactive to pass through
 
   /** The name of the range, submitted as a name/value pair with form data. */
-  @property() name = '';
+  @property() name?: string;
 
   /** The current value of the range, submitted as a name/value pair with form data. */
   @property({ type: Number }) value = 0;

--- a/src/components/textarea/textarea.test.ts
+++ b/src/components/textarea/textarea.test.ts
@@ -15,14 +15,14 @@ describe('<sl-textarea>', () => {
     const el = await fixture<SlTextarea>(html` <sl-textarea></sl-textarea> `);
 
     expect(el.size).to.equal('medium');
-    expect(el.name).to.equal('');
+    expect(el.name).to.be.undefined;
     expect(el.value).to.equal('');
     expect(el.defaultValue).to.equal('');
     expect(el.title).to.equal('');
     expect(el.filled).to.be.false;
     expect(el.label).to.equal('');
     expect(el.helpText).to.equal('');
-    expect(el.placeholder).to.equal('');
+    expect(el.placeholder).to.be.undefined;
     expect(el.rows).to.equal(4);
     expect(el.resize).to.equal('vertical');
     expect(el.disabled).to.be.false;

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -50,7 +50,7 @@ export default class SlTextarea extends ShoelaceElement implements ShoelaceFormC
   @property() title = ''; // make reactive to pass through
 
   /** The name of the textarea, submitted as a name/value pair with form data. */
-  @property() name = '';
+  @property() name?: string;
 
   /** The current value of the textarea, submitted as a name/value pair with form data. */
   @property() value = '';
@@ -68,7 +68,7 @@ export default class SlTextarea extends ShoelaceElement implements ShoelaceFormC
   @property({ attribute: 'help-text' }) helpText = '';
 
   /** Placeholder text to show as a hint when the input is empty. */
-  @property() placeholder = '';
+  @property() placeholder?: string;
 
   /** The number of rows to display by default. */
   @property({ type: Number }) rows = 4;

--- a/src/internal/form.ts
+++ b/src/internal/form.ts
@@ -30,7 +30,7 @@ export interface FormControlControllerOptions {
   /** A function that returns the form containing the form control. */
   form: (input: ShoelaceFormControl) => HTMLFormElement | null;
   /** A function that returns the form control's name, which will be submitted with the form data. */
-  name: (input: ShoelaceFormControl) => string;
+  name: (input: ShoelaceFormControl) => string | undefined;
   /** A function that returns the form control's current value. */
   value: (input: ShoelaceFormControl) => unknown | unknown[];
   /** A function that returns the form control's default value. */

--- a/src/internal/shoelace-element.ts
+++ b/src/internal/shoelace-element.ts
@@ -96,7 +96,7 @@ export default class ShoelaceElement extends LitElement {
 
 export interface ShoelaceFormControl extends ShoelaceElement {
   // Form attributes
-  name: string;
+  name?: string;
   value: unknown;
   disabled?: boolean;
   defaultValue?: unknown;


### PR DESCRIPTION
Changed some properties to have a default of `undefined` instead of `''`, fixing the extra attributes being added as mentioned in #1281

While doing this, I noticed that some other properties in Shoelace have no default value, but aren't marked optional with `?` and don't have `| undefined` in their type, nor are they assigned in the constructor. Not really sure why Typescript doesn't blow up on those, but I just left them alone for now.