### PR TITLE
Improve performance of sl-rating by not rendering all icons twice

### DIFF
--- a/src/components/rating/rating.styles.ts
+++ b/src/components/rating/rating.styles.ts
@@ -43,12 +43,19 @@ export default css`
     padding: var(--symbol-spacing);
   }
 
-  .rating__symbols--indicator {
-    position: absolute;
-    top: 0;
-    left: 0;
+  .rating__symbol--active,
+  .rating__partial--filled {
     color: var(--symbol-color-active);
-    pointer-events: none;
+  }
+
+  .rating__partial-symbol-container {
+    position: relative;
+  }
+
+  .rating__partial--filled {
+    position: absolute;
+    top: var(--symbol-spacing);
+    left: var(--symbol-spacing);
   }
 
   .rating__symbol {
@@ -79,7 +86,7 @@ export default css`
 
   /* Forced colors mode */
   @media (forced-colors: active) {
-    .rating__symbols--indicator {
+    .rating__symbol--active {
       color: SelectedItem;
     }
   }

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -252,9 +252,6 @@ export default class SlRating extends ShoelaceElement {
         <span class="rating__symbols">
           ${counter.map(index => {
             if (displayValue > index && displayValue < index + 1) {
-              const clipLeft = styleMap({ clipPath: `inset(0 ${100 - ((displayValue - index) / 1) * 100}% 0 0)` });
-              const clipRight = styleMap({ clipPath: `inset(0 0 0 ${100 - ((displayValue - index) / 1) * 100}%)` });
-
               // Users can click the current value to clear the rating. When this happens, we set this.isHovering to
               // false to prevent the hover state from confusing them as they move the mouse out of the control. This
               // extra mouseenter will reinstate it if they happen to mouse over an adjacent symbol.
@@ -268,8 +265,23 @@ export default class SlRating extends ShoelaceElement {
                   role="presentation"
                   @mouseenter=${this.handleMouseEnter}
                 >
-                  <div style=${isRtl ? clipLeft : clipRight}>${unsafeHTML(this.getSymbol(index + 1))}</div>
-                  <div class="rating__partial--filled" style=${isRtl ? clipRight : clipLeft}>
+                  <div
+                    style=${styleMap({
+                      clipPath: isRtl
+                        ? `inset(0 ${(displayValue - index) * 100}% 0 0)`
+                        : `inset(0 0 0 ${(displayValue - index) * 100}%)`
+                    })}
+                  >
+                    ${unsafeHTML(this.getSymbol(index + 1))}
+                  </div>
+                  <div
+                    class="rating__partial--filled"
+                    style=${styleMap({
+                      clipPath: isRtl
+                        ? `inset(0 0 0 ${100 - (displayValue - index) * 100}%)`
+                        : `inset(0 ${100 - (displayValue - index) * 100}% 0 0)`
+                    })}
+                  >
                     ${unsafeHTML(this.getSymbol(index + 1))}
                   </div>
                 </span>

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -249,43 +249,42 @@ export default class SlRating extends ShoelaceElement {
         @mousemove=${this.handleMouseMove}
         @touchmove=${this.handleTouchMove}
       >
-        <span class="rating__symbols rating__symbols--inactive">
+        <span class="rating__symbols">
           ${counter.map(index => {
-            // Users can click the current value to clear the rating. When this happens, we set this.isHovering to
-            // false to prevent the hover state from confusing them as they move the mouse out of the control. This
-            // extra mouseenter will reinstate it if they happen to mouse over an adjacent symbol.
+            if (displayValue > index && displayValue < index + 1) {
+              const clipLeft = styleMap({ clipPath: `inset(0 ${100 - ((displayValue - index) / 1) * 100}% 0 0)` });
+              const clipRight = styleMap({ clipPath: `inset(0 0 0 ${100 - ((displayValue - index) / 1) * 100}%)` });
+
+              // Users can click the current value to clear the rating. When this happens, we set this.isHovering to
+              // false to prevent the hover state from confusing them as they move the mouse out of the control. This
+              // extra mouseenter will reinstate it if they happen to mouse over an adjacent symbol.
+              return html`
+                <span
+                  class=${classMap({
+                    rating__symbol: true,
+                    'rating__partial-symbol-container': true,
+                    'rating__symbol--hover': this.isHovering && Math.ceil(displayValue) === index + 1
+                  })}
+                  role="presentation"
+                  @mouseenter=${this.handleMouseEnter}
+                >
+                  <div style=${isRtl ? clipLeft : clipRight}>${unsafeHTML(this.getSymbol(index + 1))}</div>
+                  <div class="rating__partial--filled" style=${isRtl ? clipRight : clipLeft}>
+                    ${unsafeHTML(this.getSymbol(index + 1))}
+                  </div>
+                </span>
+              `;
+            }
+
             return html`
               <span
                 class=${classMap({
                   rating__symbol: true,
-                  'rating__symbol--hover': this.isHovering && Math.ceil(displayValue) === index + 1
+                  'rating__symbol--hover': this.isHovering && Math.ceil(displayValue) === index + 1,
+                  'rating__symbol--active': displayValue >= index + 1
                 })}
                 role="presentation"
                 @mouseenter=${this.handleMouseEnter}
-              >
-                ${unsafeHTML(this.getSymbol(index + 1))}
-              </span>
-            `;
-          })}
-        </span>
-
-        <span class="rating__symbols rating__symbols--indicator">
-          ${counter.map(index => {
-            return html`
-              <span
-                class=${classMap({
-                  rating__symbol: true,
-                  'rating__symbol--hover': this.isHovering && Math.ceil(displayValue) === index + 1
-                })}
-                style=${styleMap({
-                  clipPath:
-                    displayValue > index + 1
-                      ? 'none'
-                      : isRtl
-                      ? `inset(0 0 0 ${100 - ((displayValue - index) / 1) * 100}%)`
-                      : `inset(0 ${100 - ((displayValue - index) / 1) * 100}% 0 0)`
-                })}
-                role="presentation"
               >
                 ${unsafeHTML(this.getSymbol(index + 1))}
               </span>


### PR DESCRIPTION
Improves the performance of `sl-rating` by only rendering each icon once instead of twice, unless it is a partially filled icon. This reduces the number of icons drawn from `2 * max` to `max + 1` (or just `max` if the current value is an integer)


This also fixes a bug where using partial transparency for icons wouldn't behave as expected because the inactive coloured icon would be visible beneath the active coloured ones:
Before: (should be red and blue, but the red blends with the blue underneath)
![image](https://user-images.githubusercontent.com/19809243/233643911-cc882629-de24-456b-860e-be474c7065ac.png)
After:
![image](https://user-images.githubusercontent.com/19809243/233644150-b0f04c95-380d-45f3-a8b5-63a126882d0b.png)

References #1279