### PR TITLE
Fix compatibility with Turbo Drive & Shoelace's autoloader

### DIFF
--- a/src/shoelace-autoloader.ts
+++ b/src/shoelace-autoloader.ts
@@ -55,4 +55,4 @@ function register(tagName: string): Promise<void> {
 discover(document.body);
 
 // Listen for new undefined elements
-observer.observe(document.body, { subtree: true, childList: true });
+observer.observe(document.documentElement, { subtree: true, childList: true });


### PR DESCRIPTION
This PR updates the observer used to auto-load unleaded Shoelace components, so that this will be compatible with Turbo Drive.

I am sure that 99% of the time the existing autoloader implementation works fine, but Turbo Drive [replaces the `<body>` tag](https://github.com/hotwired/turbo/blob/4593d06ce58d17af5b17495ad8524eaa9bc2f5d2/src/core/drive/page_renderer.ts#L7-L13) upon page render, which in turn discards the observer. Because of this, Shoelace's autoloader stops working once a page transition occurs.

I know we don't have to monitor the `<html>` tags as well as `<head>` and `<meta>` tags, but hopefully this doesn't add any noticeable overhead... Let me know if there is anything I should change (e.g. testing).

