### PR TITLE
Fix sl-input[type="date|time"] placeholder on macOS Safari

### DIFF
--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -95,7 +95,7 @@ export default css`
     height: 100%;
     color: var(--sl-input-color);
     border: none;
-    background: none;
+    background: inherit;
     box-shadow: none;
     padding: 0;
     margin: 0;


### PR DESCRIPTION
Allowing the background to inherit rather than removing it allows the weird date and time placeholder text opacity to work on macOS Safari.

- The change doesn't seem to affect macOS Firefox and Chrome. I've not tested further.
- Using inherit allows the dark and light theme background colours to come through correctly.
- Further investigation around how this interacts with 'filled' inputs is probably needed.

Fixes #1334