### PR TITLE
Add selection type "any" to sl-tree

### DIFF
--- a/docs/components/tree.md
+++ b/docs/components/tree.md
@@ -76,12 +76,14 @@ The `selection` attribute lets you change the selection behavior of the tree.
 - Use `single` to allow the selection of a single item (default).
 - Use `multiple` to allow the selection of multiple items.
 - Use `leaf` to only allow leaf nodes to be selected.
+- Use `any` to allow the selection of parent items without the need for child nodes to be selected.
 
 ```html preview
 <sl-select id="selection-mode" value="single" label="Selection">
   <sl-option value="single">Single</sl-option>
   <sl-option value="multiple">Multiple</sl-option>
   <sl-option value="leaf">Leaf</sl-option>
+  <sl-option value="any">Any</sl-option>
 </sl-select>
 
 <br />

--- a/src/components/tree/tree.test.ts
+++ b/src/components/tree/tree.test.ts
@@ -329,6 +329,24 @@ describe('<sl-tree>', () => {
           expect(el.selectedItems.length).to.eq(6);
         });
       });
+
+      describe('and selection is "any"', () => {
+        it('should toggle the selection on the tree item', async () => {
+          // Arrange
+          el.selection = 'any';
+          const node = el.children[1] as SlTreeItem;
+          node.focus();
+          await el.updateComplete;
+
+          // Act
+          await sendKeys({ press: 'Enter' });
+          await sendKeys({ press: 'ArrowRight' });
+          await sendKeys({ press: 'Enter' });
+
+          // Assert
+          expect(el.selectedItems.length).to.eq(6);
+        });
+      });
     });
 
     describe('when Space is pressed', () => {

--- a/src/components/tree/tree.ts
+++ b/src/components/tree/tree.ts
@@ -148,7 +148,7 @@ export default class SlTree extends ShoelaceElement {
 
   // Initializes new items by setting the `selectable` property and the expanded/collapsed icons if any
   private initTreeItem = (item: SlTreeItem) => {
-    item.selectable = this.selection === ('multiple' || 'any');
+    item.selectable = this.isSelectionMultiple;
 
     ['expand', 'collapse']
       .filter(status => !!this.querySelector(`[slot="${status}-icon"]`))


### PR DESCRIPTION
Hello and thank you for Shoelace! I hope this unsolicited PR is received well.

This PR introduces an additional selection type of `any` to the `<sl-tree>` component.

This selection type will treat every node in the tree as a selectable checkbox and will not uncheck them when all child nodes are unchecked.

Here's a demo:

![CleanShot 2023-05-18 at 17 06 20](https://github.com/shoelace-style/shoelace/assets/12481/1b446fc5-72e5-4dcd-bcb4-c85175f66c72)

This PR is an attempt to resolve my needs as mentioned in [this discussion](https://github.com/shoelace-style/shoelace/discussions/1342).

