### PR TITLE
Replace .map with .forEach when return value not used. See issue #740

### DIFF
--- a/src/components/tab-group/tab-group.ts
+++ b/src/components/tab-group/tab-group.ts
@@ -250,8 +250,8 @@ export default class SlTabGroup extends ShoelaceElement {
       this.activeTab = tab;
 
       // Sync active tab and panel
-      this.tabs.map(el => (el.active = el === this.activeTab));
-      this.panels.map(el => (el.active = el.name === this.activeTab?.panel));
+      this.tabs.forEach(el => (el.active = el === this.activeTab));
+      this.panels.forEach(el => (el.active = el.name === this.activeTab?.panel));
       this.syncIndicator();
 
       if (['top', 'bottom'].includes(this.placement)) {


### PR DESCRIPTION
See https://github.com/shoelace-style/shoelace/issues/740
For efficiency, do not create the additional collection as part of the .map() behaviour.
