### PR TITLE
Correct import statement for all React components

### DIFF
--- a/docs/tutorials/integrating-with-nextjs.md
+++ b/docs/tutorials/integrating-with-nextjs.md
@@ -59,7 +59,7 @@ function CustomEls({ URL }) {
       setBasePath(`${URL}/static/static`);
 
       // This imports all components
-      import('@shoelace-style/shoelace/dist/shoelace');
+      import('@shoelace-style/shoelace/dist/react');
       // If you're wanting to selectively import components, replace this line with your own definitions
 
       // import("@shoelace-style/shoelace/dist/components/button/button");


### PR DESCRIPTION
The current statement is incorrect and will result in `Module not found: Package path ./dist/shoelace is not exported from package /your/path/to/node_modules/@shoelace-style/shoelace (see exports field in /your/path/to/node_modules/@shoelace-style/shoelace/package.json)`