### PR TITLE
Add support for svg symbol sprites in <sl-icon>

### DIFF
--- a/docs/pages/components/icon.md
+++ b/docs/pages/components/icon.md
@@ -634,6 +634,29 @@ This example will load the same set of icons from the jsDelivr CDN instead of yo
 </script>
 ```
 
+### SVG Sprites
+
+To improve performance you can use a SVG sprites to avoid multiple trips for each SVG.
+
+For now we only support referencing external URLs, meaning that we don't inline and cache the result. Make sure you have the right cache headers to avoid extra requests in production.
+
+```html:preview
+<script type="module">
+  import { registerIconLibrary } from '/dist/utilities/icon-library.js';
+
+  registerIconLibrary('sprite', {
+    resolver: name => `/assets/images/sprite.svg#${name}`,
+    mutator: svg => svg.setAttribute('fill', 'currentColor'),
+    svgSymbolSprite: 'external'
+  });
+</script>
+
+<div style="font-size: 24px;">
+  <sl-icon library="sprite" name="clock"></sl-icon>
+  <sl-icon library="sprite" name="speedometer"></sl-icon>
+</div>
+```
+
 ### Customizing the System Library
 
 The system library contains only the icons used internally by Shoelace components. Unlike the default icon library, the system library does not rely on physical assets. Instead, its icons are hard-coded as data URIs into the resolver to ensure their availability.

--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -1,13 +1,14 @@
+import { type CSSResultGroup, html, type HTMLTemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { getIconLibrary, unwatchIcon, watchIcon } from './library';
+import { getIconLibrary, type IconLibrary, unwatchIcon, watchIcon } from './library';
+import { isTemplateResult } from 'lit/directive-helpers.js';
 import { watch } from '../../internal/watch';
 import ShoelaceElement from '../../internal/shoelace-element';
 import styles from './icon.styles';
-import type { CSSResultGroup } from 'lit';
 
 const CACHEABLE_ERROR = Symbol();
 const RETRYABLE_ERROR = Symbol();
-type SVGResult = SVGSVGElement | typeof RETRYABLE_ERROR | typeof CACHEABLE_ERROR;
+type SVGResult = HTMLTemplateResult | SVGSVGElement | typeof RETRYABLE_ERROR | typeof CACHEABLE_ERROR;
 
 let parser: DOMParser;
 const iconCache = new Map<string, Promise<SVGResult>>();
@@ -27,9 +28,18 @@ const iconCache = new Map<string, Promise<SVGResult>>();
 export default class SlIcon extends ShoelaceElement {
   static styles: CSSResultGroup = styles;
 
+  private initialRender = false;
+
   /** Given a URL, this function returns the resulting SVG element or an appropriate error symbol. */
-  private static async resolveIcon(url: string): Promise<SVGResult> {
+  private async resolveIcon(url: string, library?: IconLibrary): Promise<SVGResult> {
     let fileData: Response;
+
+    if (library?.svgSymbolSprite) {
+      return html`<svg @load=${() => this.emit('sl-load')} @error=${() => this.emit('sl-error')} part="base">
+        <use href="${url}"></use>
+      </svg>`;
+    }
+
     try {
       fileData = await fetch(url, { mode: 'cors' });
       if (!fileData.ok) return fileData.status === 410 ? CACHEABLE_ERROR : RETRYABLE_ERROR;
@@ -57,7 +67,7 @@ export default class SlIcon extends ShoelaceElement {
     }
   }
 
-  @state() private svg: SVGElement | null = null;
+  @state() private svg: SVGElement | HTMLTemplateResult | null = null;
 
   /** The name of the icon to draw. Available names depend on the icon library being used. */
   @property({ reflect: true }) name?: string;
@@ -83,6 +93,7 @@ export default class SlIcon extends ShoelaceElement {
   }
 
   firstUpdated() {
+    this.initialRender = true;
     this.setIcon();
   }
 
@@ -126,17 +137,28 @@ export default class SlIcon extends ShoelaceElement {
 
     let iconResolver = iconCache.get(url);
     if (!iconResolver) {
-      iconResolver = SlIcon.resolveIcon(url);
+      iconResolver = this.resolveIcon(url, library);
       iconCache.set(url, iconResolver);
     }
 
+    // If we haven't render yet, early exit. This avoids unnecessary work due to watching multiple props
+    if (!this.initialRender) {
+      return;
+    }
+
     const svg = await iconResolver;
+
     if (svg === RETRYABLE_ERROR) {
       iconCache.delete(url);
     }
 
     if (url !== this.getUrl()) {
       // If the url has changed while fetching the icon, ignore this request
+      return;
+    }
+
+    if (isTemplateResult(svg)) {
+      this.svg = svg;
       return;
     }
 

--- a/src/components/icon/library.ts
+++ b/src/components/icon/library.ts
@@ -4,10 +4,12 @@ import type SlIcon from '../icon/icon';
 
 export type IconLibraryResolver = (name: string) => string;
 export type IconLibraryMutator = (svg: SVGElement) => void;
+export type IconLibrarySymbolSprite = 'external' | 'inline';
 export interface IconLibrary {
   name: string;
   resolver: IconLibraryResolver;
   mutator?: IconLibraryMutator;
+  svgSymbolSprite?: IconLibrarySymbolSprite;
 }
 
 let registry: IconLibrary[] = [defaultLibrary, systemLibrary];
@@ -31,13 +33,14 @@ export function getIconLibrary(name?: string) {
 /** Adds an icon library to the registry, or overrides an existing one. */
 export function registerIconLibrary(
   name: string,
-  options: { resolver: IconLibraryResolver; mutator?: IconLibraryMutator }
+  options: { resolver: IconLibraryResolver; mutator?: IconLibraryMutator; svgSymbolSprite?: IconLibrarySymbolSprite }
 ) {
   unregisterIconLibrary(name);
   registry.push({
     name,
     resolver: options.resolver,
-    mutator: options.mutator
+    mutator: options.mutator,
+    svgSymbolSprite: options.svgSymbolSprite
   });
 
   // Redraw watched icons


### PR DESCRIPTION
This PR adds support for SVG sprites in `sl-icon`.

- [x] Initial implementation for review
- [ ] Add tests (need some guidance as its likely I need to reference a static asset)
- [ ] Improve docs
- [ ] Final Cleanup

### Alternatives explored

I explored the ability to use inline svg symbols (similar mechanism as currently implemented). Besides some potential caching advantages - doing the request only once - that can be quickly addressed via proper headers, it has some non-trivial runtime costs due to DOM manipulation and some observability challenges as we have to expose some elements and global ids.

### Relevant changes

- I had to make the resolveLib from the prototype to the instance since I had bind the emit and load events.
- Fixed a bug where the load and error were emitting multiple times due to the `watch` on multiple properties.

### Future work
I made the svgSymbolSprite a string in case we want to explore different alternatives in the future. Happy to change or discuss the ergonomics.
