### PR TITLE
fixes #1387

### DIFF
--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -12,6 +12,10 @@ Components with the <sl-badge variant="warning" pill>Experimental</sl-badge> bad
 
 New versions of Shoelace are released as-needed and generally occur when a critical mass of changes have accumulated. At any time, you can see what's coming in the next release by visiting [next.shoelace.style](https://next.shoelace.style).
 
+## Next
+
+- Fixed a regression that caused slotted styles to not work in `<sl-select>` [#1387](https://github.com/shoelace-style/shoelace/issues/1387)
+
 ## 2.5.0
 
 This release [unbundles Lit](https://github.com/shoelace-style/shoelace/issues/559) (and other dependencies) from Shoelace. There are now two distributions for the project:

--- a/src/components/select/select.styles.ts
+++ b/src/components/select/select.styles.ts
@@ -311,11 +311,11 @@ export default css`
     max-height: var(--auto-size-available-height);
   }
 
-  .select__listbox::slotted(sl-divider) {
+  .select__listbox ::slotted(sl-divider) {
     --spacing: var(--sl-spacing-x-small);
   }
 
-  .select__listbox::slotted(small) {
+  .select__listbox ::slotted(small) {
     font-size: var(--sl-font-size-small);
     font-weight: var(--sl-font-weight-semibold);
     color: var(--sl-color-neutral-500);


### PR DESCRIPTION
Fixes a style regression caused by wrapping `<slot>` with a container.