### PR TITLE
change carousel docs to use correct attr name, slides-per-page

### DIFF
--- a/docs/pages/components/carousel.md
+++ b/docs/pages/components/carousel.md
@@ -506,7 +506,7 @@ const App = () => {
 
 ### Multiple Slides Per View
 
-The `slides-per-view` attribute makes it possible to display multiple slides at a time. You can also use the `slides-per-move` attribute to advance more than once slide at a time, if desired.
+The `slides-per-page` attribute makes it possible to display multiple slides at a time. You can also use the `slides-per-move` attribute to advance more than once slide at a time, if desired.
 
 ```html:preview
 <sl-carousel navigation pagination slides-per-page="2" slides-per-move="2">


### PR DESCRIPTION
Corrected the name of the `slides-per-page` attribute in the docs. See: https://github.com/shoelace-style/shoelace/blob/b2aa854d982920caa2f6a5653c9a1247ffffb148/src/components/carousel/carousel.ts#L67C39-L67C39