### PR TITLE
change .floor to .ceil in getCurrentPage; modify prev function to ret…

### DIFF
--- a/src/components/carousel/carousel.ts
+++ b/src/components/carousel/carousel.ts
@@ -141,7 +141,7 @@ export default class SlCarousel extends ShoelaceElement {
   }
 
   private getCurrentPage() {
-    return Math.floor(this.activeSlide / this.slidesPerPage);
+    return Math.ceil(this.activeSlide / this.slidesPerPage);
   }
 
   private getSlides({ excludeClones = true }: { excludeClones?: boolean } = {}) {
@@ -325,7 +325,15 @@ export default class SlCarousel extends ShoelaceElement {
    * @param behavior - The behavior used for scrolling.
    */
   previous(behavior: ScrollBehavior = 'smooth') {
-    this.goToSlide(this.activeSlide - this.slidesPerMove, behavior);
+    let previousIndex = this.activeSlide || this.activeSlide - this.slidesPerMove;
+    let canSnap = false;
+
+    while (!canSnap && previousIndex > 0) {
+      previousIndex -= 1;
+      canSnap = Math.abs(previousIndex - this.slidesPerMove) % this.slidesPerMove === 0;
+    }
+
+    this.goToSlide(previousIndex, behavior);
   }
 
   /**


### PR DESCRIPTION
This PR fixes both issues noted in issue [#1304](https://github.com/shoelace-style/shoelace/issues/1304) related to carousel navigation with multiple slides per page:
1. *If you are at the end and hit the back navigation arrow, it goes back too far.*
2. *The right arrow doesn't get disabled when the end is reached and the last dot active state falls back to the previous dot sometimes.*

Issue 1 is fixed by @oncode 's  change noted in the issue; I've included their change verbatim.

Issue 2 is corrected by a fix to the `getCurrentPage` function, which doesn't always return the correct value when the slide count is not evenly divided by `slides-per-page`. 

For example, the reproduction in the issue is a 7 slide carousel with 2 slides per page and 2 slides per move. 

As you navigate, `activeSlide` goes from 0 to 2 to 4. In the subsequent "next" navigation, `activeSlide` is set to the index of the first intersecting slide, which is 5. 

At this point, `getCurrentPage` returns `Math.floor(this.activeSlide / this.slidesPerPage)`, which is `Math.floor(2.5)`, or 2, but it should really be 3:

- 1/2 (page 0)
- 3/4 (page 1)
- 5/6 (page 2)
- 6/7 (page 3)

Switching `Math.floor` to `Math.ceil` keeps the next navigations working correctly once you get to the end of these types of carousels. 


