### PR TITLE
Allow selecting menu items with space

### DIFF
--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -15,6 +15,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 ## Next
 
 - Added tests for `<sl-qr-code>` [#1416]
+- Added support for pressing [[Space]] to select/toggle selected `<sl-menu-item>` elements [#1423]
 - Fixed a bug in `<sl-qr-code>` where the `background` attribute was never passed to the QR code [#1416]
 - Fixed a bug in `<sl-dropdown>` where aria attributes were incorrectly applied to the default `<slot>` causing Lighthouse errors [#1417]
 

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -15,7 +15,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 ## Next
 
 - Added tests for `<sl-qr-code>` [#1416]
-- Added support for pressing [[Space]] to select/toggle selected `<sl-menu-item>` elements [#1423]
+- Added support for pressing [[Space]] to select/toggle selected `<sl-menu-item>` elements [#1429]
 - Fixed a bug in `<sl-qr-code>` where the `background` attribute was never passed to the QR code [#1416]
 - Fixed a bug in `<sl-dropdown>` where aria attributes were incorrectly applied to the default `<slot>` causing Lighthouse errors [#1417]
 

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -45,18 +45,13 @@ export default class SlMenu extends ShoelaceElement {
   }
 
   private handleKeyDown(event: KeyboardEvent) {
-    // Make a selection when pressing enter
-    if (event.key === 'Enter') {
+    // Make a selection when pressing enter or space
+    if (event.key === 'Enter' || event.key === ' ') {
       const item = this.getCurrentItem();
       event.preventDefault();
 
       // Simulate a click to support @click handlers on menu items that also work with the keyboard
       item?.click();
-    }
-
-    // Prevent scrolling when space is pressed
-    if (event.key === ' ') {
-      event.preventDefault();
     }
 
     // Move the selection when pressing down or up


### PR DESCRIPTION
We currently listen for <kbd>Enter</kbd> to make selections/toggle checkbox menu items. This PR also listens for space, which is [an optional but sensible behavior](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/).

Originally discussed in #1423.