### PR TITLE
1433: Add support for sl-popup "virtualAnchor"

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -263,13 +263,16 @@ if (serve) {
   });
 
   // Rebuild and reload when source files change
-  bs.watch(['src/**/!(*.test).*']).on('change', async filename => {
+  bs.watch('src/**/!(*.test).*').on('change', async filename => {
+    console.log('updated file: ', filename);
+
     try {
       const isTheme = /^src\/themes/.test(filename);
       const isStylesheet = /(\.css|\.styles\.ts)$/.test(filename);
 
       // Rebuild the source
-      await Promise.all([buildResults.map(result => result.rebuild())]);
+      const rebuildResults = buildResults.map(result => result.rebuild());
+      await Promise.all(rebuildResults);
 
       // Rebuild stylesheets when a theme file changes
       if (isTheme) {


### PR DESCRIPTION
This is by no means complete, but i wanted to get this in front of you Cory (and others) to get feedback.

Btw, build.watch() was not working for me until i made the change noted in the diff?

Cory, i know you felt like adding a new "virtualAnchor" property would be best, but the Float-UI anchor-element type is already a union of a real element + virtualElement.    
```
export type ReferenceElement = Element | VirtualElement;
```

Also, it should not really be allowed to set both the "anchor" and "virtualAnchor" properties.   We avoid that possibility if we just overloaded the "anchor" property to accept a VirtualElement.

Instead of aliasing the Float-UI VirtualElement type, i just used the Dom return type of getBoundingClientRect() : DOMRect
https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect

```
export interface VirtualElement {
  getBoundingClientRect: () => DOMRect;
}
```
DOMRect feels like a more portable.

I also limited the VirtualElement type to just the getBoundingClientRect() call.   The other Float-UI VirtualElement members are optional and seemed to be pretty specialized scenarios, so i figured that starting here would give us the core meat, and you can always expand SLPopup.VirtualElement as a future enhancement.

Let me know what you think?