### PR TITLE
Cleanup /index.html from search results

### DIFF
--- a/docs/assets/scripts/search.js
+++ b/docs/assets/scripts/search.js
@@ -284,7 +284,7 @@
         const a = document.createElement('a');
         const displayTitle = page.title ?? '';
         const displayDescription = page.description ?? '';
-        const displayUrl = page.url.replace(/^\//, '');
+        const displayUrl = page.url.replace(/^\//, '').replace(/\/$/, '');
         let icon = 'file-text';
 
         a.setAttribute('role', 'option');

--- a/docs/eleventy.config.cjs
+++ b/docs/eleventy.config.cjs
@@ -171,7 +171,10 @@ module.exports = function (eleventyConfig) {
       this.field('c'); // content
 
       results.forEach((result, index) => {
-        const url = path.join('/', path.relative(eleventyConfig.dir.output, result.outputPath)).replace(/\\/g, '/');
+        const url = path
+          .join('/', path.relative(eleventyConfig.dir.output, result.outputPath))
+          .replace(/\\/g, '/') // convert backslashes to forward slashes
+          .replace(/\/index.html$/, '/'); // convert trailing /index.html to /
         const doc = new JSDOM(result.content, {
           // We must set a default URL so links are parsed with a hostname. Let's use a bogus TLD so we can easily
           // identify which ones are internal and which ones are external.


### PR DESCRIPTION
Since moving to 11ty, we use `/tokens/color/index.html` with links pointing to `/tokens/color/`. However, I was seeing a number of `/tokens/color/index.html` URLs and realized it's coming from the site search.

This PR removes `/index.html` from page URLs and updates the search UI to display them as `tokens/color` which is much easier to scan.