### PR TITLE
Move keydown handler for sl-drawer back to base div

### DIFF
--- a/src/components/drawer/drawer.ts
+++ b/src/components/drawer/drawer.ts
@@ -143,14 +143,14 @@ export default class SlDrawer extends ShoelaceElement {
   }
 
   private addOpenListeners() {
-    document.addEventListener('keydown', this.handleDocumentKeyDown);
+    this.addEventListener('keydown', this.handleKeyDown);
   }
 
   private removeOpenListeners() {
-    document.removeEventListener('keydown', this.handleDocumentKeyDown);
+    this.removeEventListener('keydown', this.handleKeyDown);
   }
 
-  private handleDocumentKeyDown = (event: KeyboardEvent) => {
+  private handleKeyDown = (event: KeyboardEvent) => {
     if (this.open && !this.contained && event.key === 'Escape') {
       event.stopPropagation();
       this.requestClose('keyboard');
@@ -307,6 +307,7 @@ export default class SlDrawer extends ShoelaceElement {
           'drawer--rtl': this.localize.dir() === 'rtl',
           'drawer--has-footer': this.hasSlotController.test('footer')
         })}
+        @keydown=${this.handleKeyDown}
       >
         <div part="overlay" class="drawer__overlay" @click=${() => this.requestClose('overlay')} tabindex="-1"></div>
 

--- a/src/components/drawer/drawer.ts
+++ b/src/components/drawer/drawer.ts
@@ -120,6 +120,10 @@ export default class SlDrawer extends ShoelaceElement {
         lockBodyScrolling(this);
       }
     }
+    // If there is an autofocus element, let it take focuse normally, otherwise focus the panel.
+    if (!this.querySelector('[autofocus]')) {
+      this.panel.focus({ preventScroll: true });
+    }
   }
 
   disconnectedCallback() {
@@ -143,11 +147,11 @@ export default class SlDrawer extends ShoelaceElement {
   }
 
   private addOpenListeners() {
-    this.addEventListener('keydown', this.handleKeyDown);
+    this.drawer.addEventListener('keydown', this.handleKeyDown);
   }
 
   private removeOpenListeners() {
-    this.removeEventListener('keydown', this.handleKeyDown);
+    this.drawer.removeEventListener('keydown', this.handleKeyDown);
   }
 
   private handleKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
This restores the stacking behaviour of drawers.

See discussion from #1457

---

The first change broke a test case that expects an `<sl-drawer open>` can be closed by pressing Escape. Looking back at #925, I've opted to fix this by focusing the drawers panel element if the drawer is open the first time it updates. In the case of drawers that are dynamically opened, the existing code already focuses the drawer panel.