### PR TITLE
Add part to button spinner

### DIFF
--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -317,7 +317,7 @@ export default class SlButton extends ShoelaceElement implements ShoelaceFormCon
         ${
           this.caret ? html` <sl-icon part="caret" class="button__caret" library="system" name="caret"></sl-icon> ` : ''
         }
-        ${this.loading ? html`<sl-spinner></sl-spinner>` : ''}
+        ${this.loading ? html`<sl-spinner part="spinner"></sl-spinner>` : ''}
       </${tag}>
     `;
     /* eslint-enable lit/no-invalid-html */


### PR DESCRIPTION
I need to customize the color of the track when button is in loading state, but in order to do that the --track-color etc variables have to be set on the sl-spinner.
This is possible when the part is set; it seems like an oversite that it wasn't already;  it is set eg for the caret.