### PR TITLE
Fixed multiple issues in make-icons.js

### DIFF
--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -27,6 +27,8 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 - Fixed a bug in `<sl-tree>` that caused focus to be stolen when removing focused tree items [#1430]
 - Fixed a bug in `<sl-dialog>` and `<sl-drawer>` that caused nested modals to respond too eagerly to the [[Esc]] key [#1457]
 - Updated ESLint and related plugins to the latest versions
+- Fixed a compatibility issue with `bootstrap-icons` that made `make-icons.js` always download and invalidate the cache.
+- Fixed hardcoded path to `bootstrap-icons` in `make-icons.js` to make shoelace useable in npm workspaces
 
 ## 2.5.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3986,9 +3986,9 @@
       }
     },
     "node_modules/bootstrap-icons": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.10.3.tgz",
-      "integrity": "sha512-7Qvj0j0idEm/DdX9Q0CpxAnJYqBCFCiUI6qzSPYfERMcokVuV9Mdm/AJiVZI8+Gawe4h/l6zFcOzvV7oXCZArw==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.10.5.tgz",
+      "integrity": "sha512-oSX26F37V7QV7NCE53PPEL45d7EGXmBgHG3pDpZvcRaKVzWMqIRL9wcqJUyEha1esFtM3NJzvmxFXDxjJYD0jQ==",
       "dev": true
     },
     "node_modules/boxen": {
@@ -20170,9 +20170,9 @@
       }
     },
     "bootstrap-icons": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.10.3.tgz",
-      "integrity": "sha512-7Qvj0j0idEm/DdX9Q0CpxAnJYqBCFCiUI6qzSPYfERMcokVuV9Mdm/AJiVZI8+Gawe4h/l6zFcOzvV7oXCZArw==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.10.5.tgz",
+      "integrity": "sha512-oSX26F37V7QV7NCE53PPEL45d7EGXmBgHG3pDpZvcRaKVzWMqIRL9wcqJUyEha1esFtM3NJzvmxFXDxjJYD0jQ==",
       "dev": true
     },
     "boxen": {

--- a/scripts/make-icons.js
+++ b/scripts/make-icons.js
@@ -10,21 +10,82 @@ import fm from 'front-matter';
 import fs from 'fs/promises';
 import { globby } from 'globby';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+// The projects root
+const baseName = (...paths) => path.join(path.dirname(fileURLToPath(import.meta.url)), '..', ...paths);
+
+/**
+ * Recursively search for a package
+ * @param {String} packageName The package
+ * @param {String} baseDir The base directory to search for
+ * @returns Absolute path to the given npm package root dir or null if package was not found
+ */
+const getPackagePath = async (packageName, baseDir) => {
+  const searchPath = path.join(baseDir, 'node_modules', packageName);
+
+  // We have reached the root of the file system. Nothing is there, skip!
+  if (searchPath === path.join('/', 'node_modules', packageName)) {
+    return null;
+  }
+
+  try {
+    await fs.stat(searchPath);
+    return searchPath;
+  } catch {
+    return await getPackagePath(packageName, path.join(baseDir, '..'));
+  }
+};
+
+/**
+ * Get a full file path to a given file in path, providing alternative spellings if wanted
+ * @param {String} path The base path to search the files for
+ * @param {Array:String} fileNames List of file names to search for
+ * @returns The first found filename or null if nothing was found
+ */
+const getFileFromPackage = async (path, fileNames) => {
+  const [fileName, ...rest] = fileNames;
+  const filePath = `${path}/${fileName}`;
+
+  if (!fileName) {
+    return null;
+  }
+
+  try {
+    await fs.stat(filePath);
+    return filePath;
+  } catch {
+    return getFileFromPackage(path, rest);
+  }
+};
+
+// Find the package path recursively to make sure it also works in mono repos
+const iconPackagePath = await getPackagePath('bootstrap-icons', baseName('.'));
+
+if (!iconPackagePath) {
+  console.error(`
+    ${chalk.red('✘')}
+    'bootstrap-icons package was not found. Please install it via npm install --save bootstrap-icons'
+  `);
+  process.exit(1);
+}
+
+const iconPackageJSON = await getFileFromPackage(iconPackagePath, ['package.json']);
 
 const { outdir } = commandLineArgs({ name: 'outdir', type: String });
 const iconDir = path.join(outdir, '/assets/icons');
 
-const iconPackageData = JSON.parse(await fs.readFile('./node_modules/bootstrap-icons/package.json', 'utf8'));
-
+const iconPackageData = JSON.parse(await fs.readFile(iconPackageJSON, 'utf8'));
 const version = iconPackageData.version;
 const srcPath = `./.cache/icons/icons-${version}`;
 const url = `https://github.com/twbs/icons/archive/v${version}.zip`;
 
-try {
-  await fs.stat(`${srcPath}/LICENSE.md`);
-} catch {
-  // Download the source from GitHub (since not everything is published to npm)
+let iconLicense = await getFileFromPackage(srcPath, ['LICENSE.md', 'LICENSE']);
+
+// Download the source from GitHub (since not everything is published to npm)
+if (!iconLicense) {
   await download(url, './.cache/icons', { extract: true });
+  iconLicense = await getFileFromPackage(srcPath, ['LICENSE.md', 'LICENSE']);
 }
 
 // Copy icons
@@ -32,7 +93,7 @@ await deleteAsync([iconDir]);
 await fs.mkdir(iconDir, { recursive: true });
 await Promise.all([
   copy(`${srcPath}/icons`, iconDir),
-  copy(`${srcPath}/LICENSE.md`, path.join(iconDir, 'LICENSE.md')),
+  copy(iconLicense, path.join(iconDir, 'LICENSE.md')),
   copy(`${srcPath}/bootstrap-icons.svg`, './docs/assets/images/sprite.svg', { overwrite: true })
 ]);
 


### PR DESCRIPTION
- Fixed a compatibility issue with `bootstrap-icons` that made `make-icons.js` always download and invalidate the cache.
- Fixed hardcoded path to `bootstrap-icons` in `make-icons.js` to make shoelace useable in npm workspaces

Fixes https://github.com/shoelace-style/shoelace/issues/1462