### PR TITLE
feat(clipboard): add new component sl-clipboard

### DIFF
--- a/docs/pages/components/clipboard.md
+++ b/docs/pages/components/clipboard.md
@@ -1,0 +1,72 @@
+---
+meta:
+  title: Clipboard
+  description: Enables you to save content into the clipboard providing visual feedback.
+layout: component
+---
+
+```html:preview
+<div class="row">
+  <dl>
+    <dt>Phone Number</dt>
+    <dd id="phone-value">+1 234 456789</dd>
+  </dl>
+  <sl-clipboard for="phone-value"></sl-clipboard>
+</div>
+
+<style>
+  dl, .row {
+    display: flex;
+    margin: 0;
+  }
+</style>
+```
+
+```jsx:react
+import { SlClipboard } from '@shoelace-style/shoelace/dist/react';
+
+const css = `
+  dl, .row {
+    display: flex;
+    margin: 0;
+  }
+`;
+
+const App = () => (
+  <>
+    <div class="row">
+      <dl>
+        <dt>Phone Number</dt>
+        <dd id="phone-value">+1 234 456789</dd>
+      </dl>
+      <SlClipboard for="phone-value"></SlClipboard>
+    </div>
+
+    <style>{css}</style>
+  </>
+);
+```
+
+## Examples
+
+### Providing directly a text value
+
+```html:preview
+<p>Clicking the clipboard button will put "shoelace rocks" into your clipboard</p>
+<sl-clipboard value="shoelace rocks"></sl-clipboard>
+```
+
+```jsx:react
+import { SlClipboard } from '@shoelace-style/shoelace/dist/react';
+
+const App = () => (
+  <>
+    <p>Clicking the clipboard button will put "shoelace rocks" into your clipboard</p>
+    <SlClipboard value="shoelace rocks"></SlClipboard>
+  </>
+);
+```
+
+## Disclaimer
+
+The public API is partially inspired by https://github.com/github/clipboard-copy-element

--- a/docs/pages/components/clipboard.md
+++ b/docs/pages/components/clipboard.md
@@ -28,12 +28,14 @@ const App = () => (
 ```html:preview
 <sl-clipboard value="shoelace rocks">
   <button type="button">Copy to clipboard</button>
-  <button slot="copied">copied</button>
+  <button slot="copied">Copied</button>
+  <button slot="error">Error</button>
 </sl-clipboard>
 <br>
 <sl-clipboard value="shoelace rocks">
   <sl-button>Copy</sl-button>
   <sl-button slot="copied">Copied</sl-button>
+  <sl-button slot="error">Error</sl-button>
 </sl-clipboard>
 ```
 
@@ -45,6 +47,12 @@ const App = () => (
     <SlClipboard value="shoelace rocks">
       <button type="button">Copy to clipboard</button>
       <div slot="copied">copied</div>
+      <button slot="error">Error</button>
+    </SlClipboard>
+    <SlClipboard value="shoelace rocks">
+      <sl-button>Copy</sl-button>
+      <sl-button slot="copied">Copied</sl-button>
+      <sl-button slot="error">Error</sl-button>
     </SlClipboard>
   </>
 );
@@ -90,6 +98,52 @@ const App = () => (
     </div>
 
     <style>{css}</style>
+  </>
+);
+```
+
+### Error if copy fails
+
+For example if a `for` target element is not found or if not using `https`.
+An empty string value like `value=""` will also result in an error.
+
+```html:preview
+<sl-clipboard for="not-found"></sl-clipboard>
+<br>
+<sl-clipboard for="not-found">
+  <sl-button>Copy</sl-button>
+  <sl-button slot="copied">Copied</sl-button>
+  <sl-button slot="error">Error</sl-button>
+</sl-clipboard>
+```
+
+```jsx:react
+import { SlClipboard } from '@shoelace-style/shoelace/dist/react';
+
+const App = () => (
+  <>
+    <SlClipboard for="not-found"></SlClipboard>
+    <SlClipboard for="not-found">
+      <sl-button>Copy</sl-button>
+      <sl-button slot="copied">Copied</sl-button>
+      <sl-button slot="error">Error</sl-button>
+    </SlClipboard>
+  </>
+);
+```
+
+### Change duration of reset to copy button
+
+```html:preview
+<sl-clipboard value="shoelace rocks" reset-timeout="500"></sl-clipboard>
+```
+
+```jsx:react
+import { SlClipboard } from '@shoelace-style/shoelace/dist/react';
+
+const App = () => (
+  <>
+    <SlClipboard value="shoelace rocks" reset-timeout="500"></SlClipboard>
   </>
 );
 ```

--- a/docs/pages/components/clipboard.md
+++ b/docs/pages/components/clipboard.md
@@ -108,12 +108,22 @@ const App = () => (
 <input type="text" value="input rocks" id="input-rocks">
 <sl-clipboard for="input-rocks"></sl-clipboard>
 <br>
+
 <textarea id="textarea-rocks">textarea
 rocks</textarea>
 <sl-clipboard for="textarea-rocks"></sl-clipboard>
 <br>
+
 <a href="https://shoelace.style/" id="link-rocks">Shoelace</a>
 <sl-clipboard for="link-rocks"></sl-clipboard>
+<br>
+
+<sl-input value="sl-input rocks" id="sl-input-rocks"></sl-input>
+<sl-clipboard for="sl-input-rocks"></sl-clipboard>
+<br>
+
+<sl-textarea value="sl-textarea rocks" id="sl-textarea-rocks"></sl-textarea>
+<sl-clipboard for="sl-textarea-rocks"></sl-clipboard>
 ```
 
 ```jsx:react

--- a/docs/pages/components/clipboard.md
+++ b/docs/pages/components/clipboard.md
@@ -6,6 +6,53 @@ layout: component
 ---
 
 ```html:preview
+<p>Clicking the clipboard button will put "shoelace rocks" into your clipboard</p>
+<sl-clipboard value="shoelace rocks"></sl-clipboard>
+```
+
+```jsx:react
+import { SlClipboard } from '@shoelace-style/shoelace/dist/react';
+
+const App = () => (
+  <>
+    <p>Clicking the clipboard button will put "shoelace rocks" into your clipboard</p>
+    <SlClipboard value="shoelace rocks"></SlClipboard>
+  </>
+);
+```
+
+## Examples
+
+### Use your own button
+
+```html:preview
+<sl-clipboard value="shoelace rocks">
+  <button type="button">Copy to clipboard</button>
+  <button slot="copied">copied</button>
+</sl-clipboard>
+<br>
+<sl-clipboard value="shoelace rocks">
+  <sl-button>Copy</sl-button>
+  <sl-button slot="copied">Copied</sl-button>
+</sl-clipboard>
+```
+
+```jsx:react
+import { SlClipboard } from '@shoelace-style/shoelace/dist/react';
+
+const App = () => (
+  <>
+    <SlClipboard value="shoelace rocks">
+      <button type="button">Copy to clipboard</button>
+      <div slot="copied">copied</div>
+    </SlClipboard>
+  </>
+);
+```
+
+### Get the textValue from a different element
+
+```html:preview
 <div class="row">
   <dl>
     <dt>Phone Number</dt>
@@ -43,26 +90,6 @@ const App = () => (
     </div>
 
     <style>{css}</style>
-  </>
-);
-```
-
-## Examples
-
-### Providing directly a text value
-
-```html:preview
-<p>Clicking the clipboard button will put "shoelace rocks" into your clipboard</p>
-<sl-clipboard value="shoelace rocks"></sl-clipboard>
-```
-
-```jsx:react
-import { SlClipboard } from '@shoelace-style/shoelace/dist/react';
-
-const App = () => (
-  <>
-    <p>Clicking the clipboard button will put "shoelace rocks" into your clipboard</p>
-    <SlClipboard value="shoelace rocks"></SlClipboard>
   </>
 );
 ```

--- a/docs/pages/components/clipboard.md
+++ b/docs/pages/components/clipboard.md
@@ -102,6 +102,38 @@ const App = () => (
 );
 ```
 
+### Copy an input/textarea or link
+
+```html:preview
+<input type="text" value="input rocks" id="input-rocks">
+<sl-clipboard for="input-rocks"></sl-clipboard>
+<br>
+<textarea id="textarea-rocks">textarea
+rocks</textarea>
+<sl-clipboard for="textarea-rocks"></sl-clipboard>
+<br>
+<a href="https://shoelace.style/" id="link-rocks">Shoelace</a>
+<sl-clipboard for="link-rocks"></sl-clipboard>
+```
+
+```jsx:react
+import { SlClipboard } from '@shoelace-style/shoelace/dist/react';
+
+const App = () => (
+  <>
+    <input type="text" value="input rocks" id="input-rocks">
+    <SlClipboard for="input-rocks"></SlClipboard>
+    <br>
+    <textarea id="textarea-rocks">textarea
+rocks</textarea>
+    <SlClipboard for="textarea-rocks"></SlClipboard>
+    <br>
+    <a href="https://shoelace.style/" id="link-rocks">Shoelace</a>
+    <SlClipboard for="input-rocks"></SlClipboard>
+  </>
+);
+```
+
 ### Error if copy fails
 
 For example if a `for` target element is not found or if not using `https`.
@@ -146,6 +178,52 @@ const App = () => (
     <SlClipboard value="shoelace rocks" reset-timeout="500"></SlClipboard>
   </>
 );
+```
+
+### Supports Shadow Dom
+
+```html:preview
+<sl-copy-demo-el></sl-copy-demo-el>
+
+<script>
+  customElements.define('sl-copy-demo-el', class extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open' });
+    }
+
+    connectedCallback() {
+      this.shadowRoot.innerHTML = `
+        <p id="copy-me">copy me (inside shadow root)</p>
+        <sl-clipboard for="copy-me"></sl-clipboard>
+      `;
+    }
+  });
+</script>
+```
+
+```jsx:react
+import { SlClipboard } from '@shoelace-style/shoelace/dist/react';
+
+const App = () => (
+  <>
+    <sl-copy-demo-el></sl-copy-demo-el>
+  </>
+);
+
+customElements.define('sl-copy-demo-el', class extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.shadowRoot.innerHTML = `
+      <p id="copy-me">copy me (inside shadow root)</p>
+      <sl-clipboard for="copy-me"></sl-clipboard>
+    `;
+  }
+});
 ```
 
 ## Disclaimer

--- a/src/components/clipboard/clipboard.component.ts
+++ b/src/components/clipboard/clipboard.component.ts
@@ -56,6 +56,8 @@ export default class SlClipboard extends ShoelaceElement {
           this.value = target.value;
         } else if (target instanceof HTMLAnchorElement && target.hasAttribute('href')) {
           this.value = target.href;
+        } else if ('value' in target) {
+          this.value = String(target.value);
         } else {
           this.value = target.textContent || '';
         }

--- a/src/components/clipboard/clipboard.component.ts
+++ b/src/components/clipboard/clipboard.component.ts
@@ -81,6 +81,7 @@ export default class SlClipboard extends ShoelaceElement {
     return html`
       <div
         part="base"
+        aria-live="polite"
         class=${classMap({
           clipboard: true,
           [`clipboard--${this.copyStatus}`]: true

--- a/src/components/clipboard/clipboard.component.ts
+++ b/src/components/clipboard/clipboard.component.ts
@@ -1,0 +1,89 @@
+import { classMap } from 'lit/directives/class-map.js';
+import { html } from 'lit';
+import { property } from 'lit/decorators.js';
+import ShoelaceElement from '../../internal/shoelace-element.js';
+import SlIconButton from '../icon-button/icon-button.component.js';
+import SlTooltip from '../tooltip/tooltip.component.js';
+import styles from './clipboard.styles.js';
+import type { CSSResultGroup, PropertyValueMap } from 'lit';
+
+/**
+ * @summary Enables you to save content into the clipboard providing visual feedback.
+ * @documentation https://shoelace.style/components/clipboard
+ * @status experimental
+ * @since 2.0
+ *
+ * @dependency sl-icon-button
+ * @dependency sl-tooltip
+ */
+export default class SlClipboard extends ShoelaceElement {
+  static styles: CSSResultGroup = styles;
+  static dependencies = { 'sl-tooltip': SlTooltip, 'sl-icon-button': SlIconButton };
+
+  /**
+   * Indicates whether or not copy info is shown.
+   */
+  @property({ type: Boolean, reflect: true }) copy = false;
+
+  /**
+   * The value to copy.
+   */
+  @property({ type: String }) value = '';
+
+  /**
+   * The id of the element to copy the test value from.
+   */
+  @property({ type: String }) for = '';
+
+  private handleClick() {
+    if (this.copy) return;
+    this.__executeCopy();
+  }
+
+  private __executeCopy() {
+    if (this.for) {
+      const target = document.getElementById(this.for)!;
+      if (target) {
+        this.value = target.textContent || '';
+      }
+    }
+    if (this.value) {
+      navigator.clipboard.writeText(this.value);
+      this.copy = true;
+      setTimeout(() => (this.copy = false), 2000);
+    }
+  }
+
+  protected update(changedProperties: PropertyValueMap<SlClipboard> | Map<PropertyKey, unknown>): void {
+    super.update(changedProperties);
+    if (changedProperties.has('copy') && this.copy) {
+      this.__executeCopy();
+    }
+  }
+
+  render() {
+    return html`
+      <div
+        part="base"
+        class=${classMap({
+          clipboard: true,
+          'clipboard--copy': this.copy
+        })}
+      >
+        <sl-tooltip content=${this.copy ? 'Copied' : 'Copy'}>
+          <sl-icon-button
+            @click=${this.handleClick}
+            name=${this.copy ? 'file-earmark-check' : 'files'}
+            label=${this.copy ? 'Copied' : 'Copy'}
+          ></sl-icon-button>
+        </sl-tooltip>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sl-clipboard': SlClipboard;
+  }
+}

--- a/src/components/clipboard/clipboard.component.ts
+++ b/src/components/clipboard/clipboard.component.ts
@@ -49,9 +49,16 @@ export default class SlClipboard extends ShoelaceElement {
   /** Copies the clipboard */
   async copy() {
     if (this.for) {
-      const target = document.getElementById(this.for)!;
+      const root = this.getRootNode() as ShadowRoot | Document;
+      const target = 'getElementById' in root ? root.getElementById(this.for) : false;
       if (target) {
-        this.value = target.textContent || '';
+        if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+          this.value = target.value;
+        } else if (target instanceof HTMLAnchorElement && target.hasAttribute('href')) {
+          this.value = target.href;
+        } else {
+          this.value = target.textContent || '';
+        }
       }
     }
     if (this.value) {

--- a/src/components/clipboard/clipboard.styles.ts
+++ b/src/components/clipboard/clipboard.styles.ts
@@ -1,0 +1,23 @@
+import { css } from 'lit';
+import componentStyles from '../../styles/component.styles.js';
+
+export default css`
+  ${componentStyles}
+
+  :host {
+    display: inline-block;
+  }
+
+  .clipboard--copy sl-icon-button::part(base) {
+    color: var(--sl-color-success-600);
+  }
+
+  .clipboard--copy sl-icon-button::part(base):hover,
+  .clipboard--copy sl-icon-button::part(base):focus {
+    color: var(--sl-color-success-600);
+  }
+
+  .clipboard--copy sl-icon-button::part(base):active {
+    color: var(--sl-color-success-600);
+  }
+`;

--- a/src/components/clipboard/clipboard.styles.ts
+++ b/src/components/clipboard/clipboard.styles.ts
@@ -8,16 +8,47 @@ export default css`
     display: inline-block;
   }
 
-  .clipboard--copy sl-icon-button::part(base) {
+  /* successful copy */
+  slot[name='copied'] {
+    display: none;
+  }
+  .clipboard--copy #default {
+    display: none;
+  }
+  .clipboard--copy slot[name='copied'] {
+    display: block;
+  }
+
+  .green::part(base) {
+    color: var(--sl-color-success-600);
+  }
+  .green::part(base):hover,
+  .green::part(base):focus {
+    color: var(--sl-color-success-600);
+  }
+  .green::part(base):active {
     color: var(--sl-color-success-600);
   }
 
-  .clipboard--copy sl-icon-button::part(base):hover,
-  .clipboard--copy sl-icon-button::part(base):focus {
-    color: var(--sl-color-success-600);
+  /* failed to copy */
+  slot[name='copy-error'] {
+    display: none;
+  }
+  .clipboard--copy-error #default {
+    display: none;
+  }
+  .clipboard--copy-error slot[name='copy-error'] {
+    display: block;
   }
 
-  .clipboard--copy sl-icon-button::part(base):active {
-    color: var(--sl-color-success-600);
+  .red::part(base) {
+    color: var(--sl-color-danger-600);
+  }
+  .red::part(base):hover,
+  .red::part(base):focus {
+    color: var(--sl-color-danger-600);
+  }
+  .red::part(base):active {
+    color: var(--sl-color-danger-600);
   }
 `;

--- a/src/components/clipboard/clipboard.styles.ts
+++ b/src/components/clipboard/clipboard.styles.ts
@@ -12,10 +12,10 @@ export default css`
   slot[name='copied'] {
     display: none;
   }
-  .clipboard--copy #default {
+  .clipboard--copied #default {
     display: none;
   }
-  .clipboard--copy slot[name='copied'] {
+  .clipboard--copied slot[name='copied'] {
     display: block;
   }
 
@@ -31,13 +31,13 @@ export default css`
   }
 
   /* failed to copy */
-  slot[name='copy-error'] {
+  slot[name='error'] {
     display: none;
   }
-  .clipboard--copy-error #default {
+  .clipboard--error #default {
     display: none;
   }
-  .clipboard--copy-error slot[name='copy-error'] {
+  .clipboard--error slot[name='error'] {
     display: block;
   }
 

--- a/src/components/clipboard/clipboard.test.ts
+++ b/src/components/clipboard/clipboard.test.ts
@@ -19,9 +19,9 @@ describe('<sl-clipboard>', () => {
     });
 
     it('should reset copyStatus after 2 seconds', async () => {
-      expect(el.copy).to.be.false;
-      await el.copy();
-      expect(el.copyStatus).to.equal('copied');
+      expect(el.copyStatus).to.equal('trigger');
+      await el.copy(); // this will result in an error as copy needs to always be called from a user action
+      expect(el.copyStatus).to.equal('error');
       await aTimeout(2100);
       expect(el.copyStatus).to.equal('trigger');
     });

--- a/src/components/clipboard/clipboard.test.ts
+++ b/src/components/clipboard/clipboard.test.ts
@@ -1,0 +1,30 @@
+import '../../../dist/shoelace.js';
+import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import type SlClipboard from './clipboard.js';
+
+describe('<sl-clipboard>', () => {
+  let el: SlClipboard;
+
+  describe('when provided no parameters', () => {
+    before(async () => {
+      el = await fixture<SlClipboard>(html`<sl-clipboard value="something"></sl-clipboard> `);
+    });
+
+    it('should pass accessibility tests', async () => {
+      await expect(el).to.be.accessible();
+    });
+
+    it('should initially not be in copy state', () => {
+      expect(el.copy).to.false;
+    });
+
+    it('should reset copy state after 2 seconds', async () => {
+      expect(el.copy).to.be.false;
+      el.copy = true;
+      await aTimeout(1000);
+      expect(el.copy).to.be.true;
+      await aTimeout(1100);
+      expect(el.copy).to.be.false;
+    });
+  });
+});

--- a/src/components/clipboard/clipboard.test.ts
+++ b/src/components/clipboard/clipboard.test.ts
@@ -14,17 +14,16 @@ describe('<sl-clipboard>', () => {
       await expect(el).to.be.accessible();
     });
 
-    it('should initially not be in copy state', () => {
-      expect(el.copy).to.false;
+    it('should initially be in the trigger status', () => {
+      expect(el.copyStatus).to.equal('trigger');
     });
 
-    it('should reset copy state after 2 seconds', async () => {
+    it('should reset copyStatus after 2 seconds', async () => {
       expect(el.copy).to.be.false;
-      el.copy = true;
-      await aTimeout(1000);
-      expect(el.copy).to.be.true;
-      await aTimeout(1100);
-      expect(el.copy).to.be.false;
+      await el.copy();
+      expect(el.copyStatus).to.equal('copied');
+      await aTimeout(2100);
+      expect(el.copyStatus).to.equal('trigger');
     });
   });
 });

--- a/src/components/clipboard/clipboard.ts
+++ b/src/components/clipboard/clipboard.ts
@@ -1,0 +1,4 @@
+import SlClipboard from './clipboard.component.js';
+export * from './clipboard.component.js';
+export default SlClipboard;
+SlClipboard.define('sl-clipboard');

--- a/src/components/tree-item/tree-item.component.ts
+++ b/src/components/tree-item/tree-item.component.ts
@@ -12,7 +12,7 @@ import SlCheckbox from '../checkbox/checkbox.component.js';
 import SlIcon from '../icon/icon.component.js';
 import SlSpinner from '../spinner/spinner.component.js';
 import styles from './tree-item.styles.js';
-import type { CSSResultGroup, PropertyValueMap } from 'lit';
+import type { CSSResultGroup, PropertyValues } from 'lit';
 
 /**
  * @summary A tree item serves as a hierarchical node that lives inside a [tree](/components/tree).
@@ -139,7 +139,7 @@ export default class SlTreeItem extends ShoelaceElement {
     this.isLeaf = !this.lazy && this.getChildrenItems().length === 0;
   }
 
-  protected willUpdate(changedProperties: PropertyValueMap<SlTreeItem> | Map<PropertyKey, unknown>) {
+  protected willUpdate(changedProperties: PropertyValues<SlTreeItem> | Map<PropertyKey, unknown>) {
     if (changedProperties.has('selected') && !changedProperties.has('indeterminate')) {
       this.indeterminate = false;
     }

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -8,6 +8,8 @@ export type { default as SlChangeEvent } from './sl-change';
 export type { default as SlClearEvent } from './sl-clear';
 export type { default as SlCloseEvent } from './sl-close';
 export type { default as SlCollapseEvent } from './sl-collapse';
+export type { SlCopyingEvent } from './sl-copying';
+export type { SlCopiedEvent } from './sl-copied';
 export type { default as SlErrorEvent } from './sl-error';
 export type { default as SlExpandEvent } from './sl-expand';
 export type { default as SlFinishEvent } from './sl-finish';

--- a/src/events/sl-copied.ts
+++ b/src/events/sl-copied.ts
@@ -1,0 +1,7 @@
+export type SlCopiedEvent = CustomEvent<Record<PropertyKey, never>>;
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    'sl-copied': SlCopiedEvent;
+  }
+}

--- a/src/events/sl-copying.ts
+++ b/src/events/sl-copying.ts
@@ -1,0 +1,7 @@
+export type SlCopyingEvent = CustomEvent<Record<PropertyKey, never>>;
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    'sl-copying': SlCopyingEvent;
+  }
+}

--- a/src/shoelace.ts
+++ b/src/shoelace.ts
@@ -12,6 +12,7 @@ export { default as SlCard } from './components/card/card.js';
 export { default as SlCarousel } from './components/carousel/carousel.js';
 export { default as SlCarouselItem } from './components/carousel-item/carousel-item.js';
 export { default as SlCheckbox } from './components/checkbox/checkbox.js';
+export { default as SlClipboard } from './components/clipboard/clipboard.js';
 export { default as SlColorPicker } from './components/color-picker/color-picker.js';
 export { default as SlDetails } from './components/details/details.js';
 export { default as SlDialog } from './components/dialog/dialog.js';


### PR DESCRIPTION
## What I did

- Add a new component `sl-clipboard`
- It shows a copy icon button
- Component reads `for` to get text content from an element with an id OR a value directly
- On click it changes to a different icon and tooltip text "copied"
- After 2s it resets back to the original copy button and text "copy"
- Add it to docs
- Add basics tests (cannot test copy function itself as accessing clipboard in tests is currently not possible 😅)


![clipboard](https://github.com/shoelace-style/shoelace/assets/24378/3ee1b758-aea3-4379-bd15-158c8a9bc8aa)

closes https://github.com/shoelace-style/shoelace/issues/1471