### PR TITLE
fix: react tree shaking and non-react entrypoint tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "sideEffects": [
     "./dist/shoelace.js",
     "./dist/shoelace-autoloader.js",
-    "./dist/components/**/*.js",
-    "./dist/chunks/**/*.js",
+    "./dist/components/**/*.*",
+    "./dist/chunks/**/*.*",
     "./dist/translations/**/*.*",
     "./src/translations/**/*.*",
     "*.css",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -93,7 +93,7 @@ async function buildTheSource() {
       // Public utilities
       ...(await globby('./src/utilities/**/!(*.(style|test)).ts')),
       // Theme stylesheets
-      ...(await globby('./src/themes/**/!(*.test).ts')),
+      ...(await globby('./src/themes/**/!(*.test).ts'))
     ],
     outdir: cdndir,
     chunkNames: 'chunks/[name].[hash]',
@@ -132,23 +132,19 @@ async function buildTheSource() {
       ...(await globby('./src/react/**/*.ts'))
     ],
     outdir: 'dist/react',
-    chunkNames: 'react-chunks/[name].[hash]',
-  }
+    chunkNames: 'react-chunks/[name].[hash]'
+  };
 
-  const configs = [
-    cdnConfig,
-    npmConfig,
-    reactConfig
-  ]
+  const configs = [cdnConfig, npmConfig, reactConfig];
 
   if (serve) {
     // Use the context API to allow incremental dev builds
-    const contexts = await Promise.all(configs.map((config) => esbuild.context(config)));
+    const contexts = await Promise.all(configs.map(config => esbuild.context(config)));
     await Promise.all(contexts.map(context => context.rebuild()));
     return contexts;
   } else {
     // Use the standard API for production builds
-    return await Promise.all(configs.map((config) => esbuild.build(config)));
+    return await Promise.all(configs.map(config => esbuild.build(config)));
   }
 }
 

--- a/scripts/make-react.js
+++ b/scripts/make-react.js
@@ -24,7 +24,7 @@ components.map(component => {
   const tagWithoutPrefix = component.tagName.replace(/^sl-/, '');
   const componentDir = path.join(reactDir, tagWithoutPrefix);
   const componentFile = path.join(componentDir, 'index.ts');
-  const importPath = component.path;
+  const importPath = component.path.split(/\.js$/)[0] + ".component.js";
   const eventImports = (component.events || [])
     .map(event => `import { ${event.eventName} } from '../../../src/events/events';`)
     .join('\n');

--- a/scripts/make-react.js
+++ b/scripts/make-react.js
@@ -24,7 +24,7 @@ components.map(component => {
   const tagWithoutPrefix = component.tagName.replace(/^sl-/, '');
   const componentDir = path.join(reactDir, tagWithoutPrefix);
   const componentFile = path.join(componentDir, 'index.ts');
-  const importPath = component.path.split(/\.js$/)[0] + ".component.js";
+  const importPath = component.path.split(/\.js$/)[0] + '.component.js';
   const eventImports = (component.events || [])
     .map(event => `import { ${event.eventName} } from '../../../src/events/events';`)
     .join('\n');


### PR DESCRIPTION
😮‍💨 I think I got the treeshaking stuff down. Brief checks with Vite + Webpack builds seem to work.

This does introduce the caveat if you import a Shoelace component and a React component, you're doubling your build size. But I think this is a fair tradeoff.