### PR TITLE
Fix menu focus when there are disabled items

### DIFF
--- a/docs/pages/components/menu.md
+++ b/docs/pages/components/menu.md
@@ -9,30 +9,68 @@ You can use [menu items](/components/menu-item), [menu labels](/components/menu-
 
 ```html:preview
 <sl-menu style="max-width: 200px;">
-  <sl-menu-item value="undo">Undo</sl-menu-item>
-  <sl-menu-item value="redo">Redo</sl-menu-item>
+  <sl-menu-item value="undo">
+    <sl-icon slot="prefix" name="arrow-counterclockwise"></sl-icon>
+    Undo
+  </sl-menu-item>
+  <sl-menu-item value="redo" disabled>
+    <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+    Redo
+  </sl-menu-item>
   <sl-divider></sl-divider>
-  <sl-menu-item value="cut">Cut</sl-menu-item>
-  <sl-menu-item value="copy">Copy</sl-menu-item>
-  <sl-menu-item value="paste">Paste</sl-menu-item>
-  <sl-menu-item value="delete">Delete</sl-menu-item>
+  <sl-menu-item value="cut">
+    <sl-icon slot="prefix" name="scissors"></sl-icon>
+    Cut
+  </sl-menu-item>
+  <sl-menu-item value="copy">
+    <sl-icon slot="prefix" name="files"></sl-icon>
+    Copy
+  </sl-menu-item>
+  <sl-menu-item value="paste" disabled>
+    <sl-icon slot="prefix" name="clipboard-check"></sl-icon>
+    Paste
+  </sl-menu-item>
+  <sl-divider></sl-divider>
+  <sl-menu-item value="delete">
+    <sl-icon slot="prefix" name="trash"></sl-icon>
+    Delete
+  </sl-menu-item>
 </sl-menu>
 ```
 
 {% raw %}
 
 ```jsx:react
-import { SlDivider, SlMenu, SlMenuItem } from '@shoelace-style/shoelace/dist/react';
+import { SlDivider, SlIcon, SlMenu, SlMenuItem } from '@shoelace-style/shoelace/dist/react';
 
 const App = () => (
   <SlMenu style={{ maxWidth: '200px' }}>
-    <SlMenuItem value="undo">Undo</SlMenuItem>
-    <SlMenuItem value="redo">Redo</SlMenuItem>
+    <SlMenuItem value="undo">
+      <SlIcon slot="prefix" name="arrow-counterclockwise" />
+      Undo
+    </SlMenuItem>
+    <SlMenuItem value="redo" disabled>
+      <SlIcon slot="prefix" name="arrow-clockwise" />
+      Redo
+    </SlMenuItem>
     <SlDivider />
-    <SlMenuItem value="cut">Cut</SlMenuItem>
-    <SlMenuItem value="copy">Copy</SlMenuItem>
-    <SlMenuItem value="paste">Paste</SlMenuItem>
-    <SlMenuItem value="delete">Delete</SlMenuItem>
+    <SlMenuItem value="cut">
+      <SlIcon slot="prefix" name="scissors" />
+      Cut
+    </SlMenuItem>
+    <SlMenuItem value="copy">
+      <SlIcon slot="prefix" name="files" />
+      Copy
+    </SlMenuItem>
+    <SlMenuItem value="paste" disabled>
+      <SlIcon slot="prefix" name="clipboard-check" />
+      Paste
+    </SlMenuItem>
+    <SlDivider />
+    <SlMenuItem value="delete">
+      <SlIcon slot="prefix" name="trash" />
+      Delete
+    </SlMenuItem>
   </SlMenu>
 );
 ```

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -15,6 +15,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 ## Next
 
 - Fixed a bug in `<sl-dropdown>` where pressing [[Up]] or [[Down]] when focused on the trigger wouldn't focus the first/last menu items [#1472]
+- Fixed a bug in `<sl-menu>` where pressing [[Up]], [[Down]], [[Home]] or [[End]] failed when there were disabled menu items.
 
 ## 2.6.0
 

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -15,8 +15,8 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 ## Next
 
 - Fixed a bug in `<sl-dropdown>` where pressing [[Up]] or [[Down]] when focused on the trigger wouldn't focus the first/last menu items [#1472]
-- Fixed a bug in `<sl-menu>` where pressing [[Up]], [[Down]], [[Home]] or [[End]] failed when there were disabled menu items.
-- Fixed a bug in `<sl-menu-menu>` where `aria-disabled` weren't applied on a `disabled` menu item.
+- Fixed a bug in `<sl-menu>` where pressing [[Up]], [[Down]], [[Home]] or [[End]] failed when there were disabled menu items. [#1494]
+- Fixed a bug in `<sl-menu-menu>` where `aria-disabled` weren't applied on a `disabled` menu item. [#1494]
 
 ## 2.6.0
 

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -16,6 +16,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 
 - Fixed a bug in `<sl-dropdown>` where pressing [[Up]] or [[Down]] when focused on the trigger wouldn't focus the first/last menu items [#1472]
 - Fixed a bug in `<sl-menu>` where pressing [[Up]], [[Down]], [[Home]] or [[End]] failed when there were disabled menu items.
+- Fixed a bug in `<sl-menu-menu>` where `aria-disabled` weren't applied on a `disabled` menu item.
 
 ## 2.6.0
 

--- a/src/components/menu-item/menu-item.component.ts
+++ b/src/components/menu-item/menu-item.component.ts
@@ -112,6 +112,7 @@ export default class SlMenuItem extends ShoelaceElement {
           'menu-item--disabled': this.disabled,
           'menu-item--has-submenu': false // reserved for future use
         })}
+        aria-disabled=${this.disabled ? 'true' : 'false'}
       >
         <span part="checked-icon" class="menu-item__check">
           <sl-icon name="check" library="system" aria-hidden="true"></sl-icon>

--- a/src/components/menu/menu.component.ts
+++ b/src/components/menu/menu.component.ts
@@ -55,28 +55,34 @@ export default class SlMenu extends ShoelaceElement {
 
     // Move the selection when pressing down or up
     if (['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
-      const items = this.getAllItems();
-      const activeItem = this.getCurrentItem();
-      let index = activeItem ? items.indexOf(activeItem) : 0;
+      const items = this.getAllItems().filter(item => !item.disabled);
 
-      if (items.length > 0) {
+      if (items.length > 1) {
         event.preventDefault();
+        const activeItem = this.getCurrentItem();
+        let index = activeItem ? items.indexOf(activeItem) : 0;
+        let isFocusableItem = false;
 
-        if (event.key === 'ArrowDown') {
-          index++;
-        } else if (event.key === 'ArrowUp') {
-          index--;
-        } else if (event.key === 'Home') {
-          index = 0;
-        } else if (event.key === 'End') {
-          index = items.length - 1;
-        }
+        while (!isFocusableItem) {
+          if (event.key === 'ArrowDown') {
+            index++;
+          } else if (event.key === 'ArrowUp') {
+            index--;
+          } else if (event.key === 'Home') {
+            index = 0;
+          } else if (event.key === 'End') {
+            index = items.length - 1;
+          }
 
-        if (index < 0) {
-          index = items.length - 1;
-        }
-        if (index > items.length - 1) {
-          index = 0;
+          if (index < 0) {
+            index = items.length - 1;
+          } else if (index > items.length - 1) {
+            index = 0;
+          }
+
+          if (!items[index].disabled) {
+            isFocusableItem = true;
+          }
         }
 
         this.setCurrentItem(items[index]);
@@ -136,7 +142,7 @@ export default class SlMenu extends ShoelaceElement {
 
     // Update tab indexes
     items.forEach(i => {
-      i.setAttribute('tabindex', i === item ? '0' : '-1');
+      i.setAttribute('tabindex', i === item && !item.disabled ? '0' : '-1');
     });
   }
 


### PR DESCRIPTION
Solves #1494:
- Fixed a bug in `<sl-menu>` where pressing `Up`, `Down`, `Home` or `End` failed when there were disabled menu items.
- Fixed a bug in `<sl-menu-menu>` where `aria-disabled` weren't applied on a `disabled` menu item.