### PR TITLE
feat: export system icons to allow individual overrides

### DIFF
--- a/src/components/icon/library.system.ts
+++ b/src/components/icon/library.system.ts
@@ -7,7 +7,7 @@ import type { IconLibrary } from './library.js';
 // All Shoelace components must use the system library instead of the default library. For visual consistency, system
 // icons are a subset of Bootstrap Icons.
 //
-const icons = {
+export const icons = {
   caret: `
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="6 9 12 15 18 9"></polyline>


### PR DESCRIPTION
* Export the inline SVG icons from the system icon set so that  overriding just one of them is easier, and overrides are future-proof (if a new one is added, it is used automatically). The goal is to make it possible to create the same type of inline asset table for building data-uris as the default library uses.

Docs: [Customizing the System Library](https://shoelace.style/components/icon#customizing-the-system-library)


```ts
import { registerIconLibrary } from '/dist/utilities/icon-library.js';
import { icons as baseIcons } from '/dist/components/icon/library.system.js';

const icons = {
  ...baseIcons,
  // custom overrides
  'x-circle-fill': `
    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-circle-fill" viewBox="0 0 16 16">
      <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.354 4.646a.5.5 0 1 0-.708.708L7.293 8l-2.647 2.646a.5.5 0 0 0 .708.708L8 8.707l2.646 2.647a.5.5 0 0 0 .708-.708L8.707 8l2.647-2.646a.5.5 0 0 0-.708-.708L8 7.293 5.354 4.646z"></path>
    </svg>
  `
}

registerIconLibrary({
  name: 'system',
  resolver: (name: keyof typeof icons) => {
    if (name in icons) {
      return `data:image/svg+xml,${encodeURIComponent(icons[name])}`;
    }
    return '';
  }
});

```