### PR TITLE
Expand on comment about space-separated value for sl-select

### DIFF
--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -97,7 +97,10 @@ export default class SlSelect extends ShoelaceElement implements ShoelaceFormCon
 
   /**
    * The current value of the select, submitted as a name/value pair with form data. When `multiple` is enabled, the
-   * value will be a space-delimited list of values based on the options selected.
+   * value attribute will be a space-delimited list of values based on the options selected, and the value property
+   * will be an array.
+   *
+   * **Note** For this reason, SlOption values must not contain spaces.
    */
   @property({
     converter: {


### PR DESCRIPTION
I spent a while debugging the array vs space-separated string issue while upgrading from the pre-2.0 API which used menu-items instead of options and did not have this restriction.

Hoping that this comment will help others.