### PR TITLE
Fix missing comma in linear-gradient

### DIFF
--- a/src/components/color-picker/color-picker.component.ts
+++ b/src/components/color-picker/color-picker.component.ts
@@ -882,7 +882,7 @@ export default class SlColorPicker extends ShoelaceElement implements ShoelaceFo
                       style=${styleMap({
                         backgroundImage: `linear-gradient(
                           to right,
-                          ${this.getHexString(this.hue, this.saturation, this.brightness, 0)} 0%
+                          ${this.getHexString(this.hue, this.saturation, this.brightness, 0)} 0%,
                           ${this.getHexString(this.hue, this.saturation, this.brightness, 100)} 100%
                         )`
                       })}


### PR DESCRIPTION
Firefox & Opera being picky about missing comma.

https://www.w3.org/TR/css-images-3/#typedef-color-stop-list

![image](https://github.com/shoelace-style/shoelace/assets/140904760/ce7ae02f-07e9-4ccc-9ec9-b90908e16307)
