### PR TITLE
Expand sl-tree-item on first selection.

### DIFF
--- a/src/components/tree/tree.component.ts
+++ b/src/components/tree/tree.component.ts
@@ -192,7 +192,11 @@ export default class SlTree extends ShoelaceElement {
       }
       this.syncTreeItems(selectedItem);
     } else if (this.selection === 'single' || selectedItem.isLeaf) {
-      selectedItem.expanded = !selectedItem.expanded;
+      if (selectedItem.selected) {
+        selectedItem.expanded = !selectedItem.expanded;
+      } else {
+        selectedItem.expanded = true;
+      }
       selectedItem.selected = true;
 
       this.syncTreeItems(selectedItem);


### PR DESCRIPTION
Previously, an sl-tree with the 'single' selection mode would always toggle the expanded state of an item when selecting it, which leads to an unusual behaviour: selecting an expanded (but not previously selected) item collapses it.

This changes the behaviour of 'single' mode so that an item is always expanded when it is first selected. Clicking an item that was already selected then toggles it's expanded state.

---

See related discussion in https://github.com/shoelace-style/shoelace/discussions/1159