### PR TITLE
SlTree: separate expand/collapse and selection behaviour in 'single' mode

### DIFF
--- a/src/components/tree/tree.component.ts
+++ b/src/components/tree/tree.component.ts
@@ -311,7 +311,7 @@ export default class SlTree extends ShoelaceElement {
       return;
     }
 
-    if (this.selection === 'multiple' && isExpandButton) {
+    if (isExpandButton) {
       treeItem.expanded = !treeItem.expanded;
     } else {
       this.selectItem(treeItem);

--- a/src/components/tree/tree.component.ts
+++ b/src/components/tree/tree.component.ts
@@ -168,20 +168,6 @@ export default class SlTree extends ShoelaceElement {
     }
   };
 
-  private syncTreeItems(selectedItem: SlTreeItem) {
-    const items = this.getAllTreeItems();
-
-    if (this.selection === 'multiple') {
-      syncCheckboxes(selectedItem);
-    } else {
-      for (const item of items) {
-        if (item !== selectedItem) {
-          item.selected = false;
-        }
-      }
-    }
-  }
-
   private selectItem(selectedItem: SlTreeItem) {
     const previousSelection = [...this.selectedItems];
 
@@ -190,12 +176,14 @@ export default class SlTree extends ShoelaceElement {
       if (selectedItem.lazy) {
         selectedItem.expanded = true;
       }
-      this.syncTreeItems(selectedItem);
+      syncCheckboxes(selectedItem);
     } else if (this.selection === 'single' || selectedItem.isLeaf) {
       selectedItem.expanded = !selectedItem.expanded;
-      selectedItem.selected = true;
 
-      this.syncTreeItems(selectedItem);
+      const items = this.getAllTreeItems();
+      for (const item of items) {
+        item.selected = (item === selectedItem);
+      }
     } else if (this.selection === 'leaf') {
       selectedItem.expanded = !selectedItem.expanded;
     }

--- a/src/components/tree/tree.component.ts
+++ b/src/components/tree/tree.component.ts
@@ -178,8 +178,6 @@ export default class SlTree extends ShoelaceElement {
       }
       syncCheckboxes(selectedItem);
     } else if (this.selection === 'single' || selectedItem.isLeaf) {
-      selectedItem.expanded = !selectedItem.expanded;
-
       const items = this.getAllTreeItems();
       for (const item of items) {
         item.selected = (item === selectedItem);


### PR DESCRIPTION
This changes the behaviour of sl-tree so that clicking on the expand/collapse icon will not select/deselect the item, only toggle it's expanded state.

See also: #1517 and discussion in #1159
