### PR TITLE
fix(docs): Inline Form Validation Docs throw error on top level await

### DIFF
--- a/docs/pages/getting-started/form-controls.md
+++ b/docs/pages/getting-started/form-controls.md
@@ -462,7 +462,7 @@ To disable the browser's error messages, you need to cancel the `sl-invalid` eve
   <sl-button type="reset" variant="default">Reset</sl-button>
 </form>
 
-<script>
+<script type="module">
   const form = document.querySelector('.inline-validation');
   const nameError = document.querySelector('#name-error');
 


### PR DESCRIPTION
demo currently throws an error and therefore the demo does not show how inline form validation work