### PR TITLE
remove baseUrl from tsconfig for better dev experience

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "useUnknownInCatchVariables": true,
-    "baseUrl": ".",
     "types": [
       "mocha",
       "user-agent-data-types"

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "./src"
   },
   "include": ["src"],


### PR DESCRIPTION
Ever wonder why sometimes in your editor the completion gives you `import "src/components/button/button.component.js"` instead of a relative specifier like this:
`import "../button/button.component.js"`


Turns out there's a super fun property in `tsconfig.json`  called `"baseUrl"` that causes these annoying paths.

>  `baseUrl`
> This feature was designed for use in conjunction with AMD module loaders in the browser, and is not recommended in  any other context. As of TypeScript 4.1, baseUrl is no longer required to be set when using paths.

https://www.typescriptlang.org/tsconfig#baseUrl





