### PR TITLE
fix empty attributes in properties table

### DIFF
--- a/docs/_includes/component.njk
+++ b/docs/_includes/component.njk
@@ -137,15 +137,17 @@
           <tr>
             <td>
               <code class="nowrap">{{ prop.name }}</code>
-              {% if prop.attribute != prop.name %}
-                <br>
-                <sl-tooltip content="This attribute is different from its property">
-                  <small>
-                    <code class="nowrap">
-                      {{ prop.attribute }}
-                    </code>
-                  </small>
-                </sl-tooltip>
+              {% if prop.attribute | length > 0 %}
+                {% if prop.attribute != prop.name %}
+                  <br>
+                  <sl-tooltip content="This attribute is different from its property">
+                    <small>
+                      <code class="nowrap">
+                        {{ prop.attribute }}
+                      </code>
+                    </small>
+                  </sl-tooltip>
+                {% endif %}
               {% endif %}
             </td>
             <td>


### PR DESCRIPTION
Fixes this, which occurs when properties don't have corresponding attributes.

![CleanShot 2023-08-22 at 16 58 03@2x](https://github.com/shoelace-style/shoelace/assets/55639/1d4dc48d-28b7-4555-9899-e042b655ed0d)
