### PR TITLE
fix: make German translation more consistent + neutral

### DIFF
--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -13,7 +13,7 @@ const translation: Translation = {
   copy: 'Kopieren',
   currentValue: 'Aktueller Wert',
   error: 'Fehler',
-  goToSlide: (slide, count) => `Gehen Sie zu Folie ${slide} von ${count}`,
+  goToSlide: (slide, count) => `Zu Folie ${slide} von ${count} gehen`,
   hidePassword: 'Passwort verbergen',
   loading: 'Wird geladen',
   nextSlide: 'Nächste Folie',
@@ -28,7 +28,7 @@ const translation: Translation = {
   resize: 'Größe ändern',
   scrollToEnd: 'Zum Ende scrollen',
   scrollToStart: 'Zum Anfang scrollen',
-  selectAColorFromTheScreen: 'Wähle eine Farbe vom Bildschirm',
+  selectAColorFromTheScreen: 'Farbe vom Bildschirm auswählen',
   showPassword: 'Passwort anzeigen',
   slideNum: slide => `Folie ${slide}`,
   toggleColorFormat: 'Farbformat umschalten'


### PR DESCRIPTION
In German you can say "Du" (=informal, personal) or "Sie" (= formal, polite, some kind of "thou"). Before this commit both versions were used at the same time:

- "Wähle [= implicit "Du"] eine Farbe vom Bildschirm" → informal
- "Gehen Sie zu Folie ${slide} von ${count}" → formal

 It is preferred to make interfaces neutral, as some systems use "Du" (iOS, macOS) and some "Sie" (MS, Android). In addition all other translations were neutral, too, so this makes it more consistent.

This change removes any implicit or explicit "Du" or "Sie" and uses more neutral, interface-like descriptions.