### PR TITLE
fix: add missing super.disconnectCallback() calls

### DIFF
--- a/src/components/details/details.component.ts
+++ b/src/components/details/details.component.ts
@@ -87,6 +87,7 @@ export default class SlDetails extends ShoelaceElement {
   }
 
   disconnectedCallback() {
+    super.disconnectedCallback();
     this.detailsObserver.disconnect();
   }
 

--- a/src/components/mutation-observer/mutation-observer.component.ts
+++ b/src/components/mutation-observer/mutation-observer.component.ts
@@ -52,6 +52,7 @@ export default class SlMutationObserver extends ShoelaceElement {
   }
 
   disconnectedCallback() {
+    super.disconnectedCallback();
     this.stopObserver();
   }
 

--- a/src/components/popup/popup.component.ts
+++ b/src/components/popup/popup.component.ts
@@ -198,6 +198,7 @@ export default class SlPopup extends ShoelaceElement {
   }
 
   disconnectedCallback() {
+    super.disconnectedCallback();
     this.stop();
   }
 

--- a/src/components/tab-group/tab-group.component.ts
+++ b/src/components/tab-group/tab-group.component.ts
@@ -117,6 +117,7 @@ export default class SlTabGroup extends ShoelaceElement {
   }
 
   disconnectedCallback() {
+    super.disconnectedCallback();
     this.mutationObserver.disconnect();
     this.resizeObserver.unobserve(this.nav);
   }


### PR DESCRIPTION
## Problem
During some memory leak tests in our app that uses shoelace components, we identified a problem within the popup.disconnectCallback() function. The `super.disconnectCallback()` call is missing.

## Solution
Add `super.disconnectCallback()`, like it is done in other components.

## Scope
I also checked all the other components and added the missing `super.disconnectCallback()` call.

## Future improvement ideas
- Add a custom eslint rule to check for super calls
- Use the [symbol pattern method](https://github.com/microsoft/TypeScript/issues/21388#issuecomment-934345226) in the `ShoelaceElement` class to create a TS error
- Add a pattern (unit) test (scan for all components)


This is my first PR to shoelace, so let me know how to improve the PR to meet the project quality guidelines.


 