### PR TITLE
updated @lit-labs/react for improved types with preact

### DIFF
--- a/docs/pages/frameworks/react.md
+++ b/docs/pages/frameworks/react.md
@@ -32,6 +32,10 @@ If you'd rather not use the CDN for assets, you can create a [build task](https:
 
 Now you can start using components!
 
+### Preact
+
+Preact users facing type errors using components may benefit from setting "paths" in their tsconfig.json so that react types will instead resolve to preact/compat as described in [Preact's typescript documentation](https://preactjs.com/guide/v10/typescript/#typescript-preactcompat-configuration).
+
 ## Usage
 
 ### Importing Components

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.1",
         "@floating-ui/dom": "^1.2.1",
-        "@lit-labs/react": "^2.0.1",
+        "@lit-labs/react": "^2.0.3",
         "@shoelace-style/animations": "^1.1.0",
         "@shoelace-style/localize": "^3.1.1",
         "composed-offset-position": "^0.0.4",
@@ -1474,9 +1474,9 @@
       }
     },
     "node_modules/@lit-labs/react": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-2.0.1.tgz",
-      "integrity": "sha512-Nj+XB3HamqaWefN91lpFPJaqjJ78XzGkPWCedB4jyH22GBFEenpE9A/h8B/2dnIGXtNtd9D/RFpUdQ/dBtWFqA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-2.0.3.tgz",
+      "integrity": "sha512-lSvWbTrbxWqYv/iiOwbAEJfFZrKjO/QjJ4IEXhg43sdD5fNFz4wRXpVsntfVn4DnxpQd+NVRnrsF2USgK0XCTw==",
       "peerDependencies": {
         "@types/react": "17 || 18"
       }
@@ -18290,9 +18290,9 @@
       }
     },
     "@lit-labs/react": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-2.0.1.tgz",
-      "integrity": "sha512-Nj+XB3HamqaWefN91lpFPJaqjJ78XzGkPWCedB4jyH22GBFEenpE9A/h8B/2dnIGXtNtd9D/RFpUdQ/dBtWFqA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-2.0.3.tgz",
+      "integrity": "sha512-lSvWbTrbxWqYv/iiOwbAEJfFZrKjO/QjJ4IEXhg43sdD5fNFz4wRXpVsntfVn4DnxpQd+NVRnrsF2USgK0XCTw==",
       "requires": {}
     },
     "@lit-labs/ssr-dom-shim": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@ctrl/tinycolor": "^4.0.1",
     "@floating-ui/dom": "^1.2.1",
-    "@lit-labs/react": "^2.0.1",
+    "@lit-labs/react": "^2.0.3",
     "@shoelace-style/animations": "^1.1.0",
     "@shoelace-style/localize": "^3.1.1",
     "composed-offset-position": "^0.0.4",


### PR DESCRIPTION
Fixes #868

Latest version of `@lit-labs/react` includes some nice type improvements for preact, [here](https://github.com/lit/lit/pull/4172).

Also added a small preact specific section to the react installation docs.
