### PR TITLE
Load SVG from URL correctly when default library is sprite

### DIFF
--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -19,6 +19,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 - Removed error when a missing popup anchor is provided [#1548]
 - Updated `@ctrl/tinycolor` to 4.0.1 [#1542]
 - Updated Bootstrap Icons to 1.11.0
+- Fixed a bug in `<sl-icon>` where we load svg URL via `<use>` if the default icon library was changed to be a sprite.
 
 ## 2.8.0
 


### PR DESCRIPTION
I switched the default icon library to load our custom icon sprite.
When I tried to load an SVG from URL, it wasn't working. <sl-icon> was still using <use>, even though I was setting `src`, not `name`.

A quick look at the code confirmed that we weren't checking if the URL was sourced in a library or not.

It's a pretty small and simple code change, but there's a dozen and one variations, depending on code style preferences.