### PR TITLE
fix: multiple slides per page navigation

### DIFF
--- a/src/components/carousel-item/carousel-item.component.ts
+++ b/src/components/carousel-item/carousel-item.component.ts
@@ -17,10 +17,6 @@ import type { CSSResultGroup } from 'lit';
 export default class SlCarouselItem extends ShoelaceElement {
   static styles: CSSResultGroup = styles;
 
-  static isCarouselItem(node: Node) {
-    return node instanceof Element && node.getAttribute('aria-roledescription') === 'slide';
-  }
-
   connectedCallback() {
     super.connectedCallback();
     this.setAttribute('role', 'group');

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -303,7 +303,7 @@ export default class SlCarousel extends ShoelaceElement {
       this.emit('sl-slide-change', {
         detail: {
           index: this.activeSlide,
-          slide: this.getSlides()[this.activeSlide]
+          slide: slides[this.activeSlide]
         }
       });
     }

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -1,3 +1,5 @@
+import '../../internal/scrollend-polyfill.js';
+
 import { AutoplayController } from './autoplay-controller.js';
 import { clamp } from '../../internal/math.js';
 import { classMap } from 'lit/directives/class-map.js';

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -231,7 +231,9 @@ export default class SlCarousel extends ShoelaceElement {
 
   private handleSlotChange = (mutations: MutationRecord[]) => {
     const needsInitialization = mutations.some(mutation =>
-      [...mutation.addedNodes, ...mutation.removedNodes].some(this.isCarouselItem)
+      [...mutation.addedNodes, ...mutation.removedNodes].some(
+        (el: HTMLElement) => this.isCarouselItem(el) && !el.hasAttribute('data-clone')
+      )
     );
 
     // Reinitialize the carousel if a carousel item has been added or removed

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -14,7 +14,7 @@ import { watch } from '../../internal/watch.js';
 import ShoelaceElement from '../../internal/shoelace-element.js';
 import SlIcon from '../icon/icon.component.js';
 import styles from './carousel.styles.js';
-import type { CSSResultGroup } from 'lit';
+import type { CSSResultGroup, PropertyValueMap } from 'lit';
 import type SlCarouselItem from '../carousel-item/carousel-item.component.js';
 
 /**
@@ -70,7 +70,7 @@ export default class SlCarousel extends ShoelaceElement {
 
   /**
    * Specifies the number of slides the carousel will advance when scrolling, useful when specifying a `slides-per-page`
-   * greater than one.
+   * greater than one. It can't be higher than `slides-per-page`.
    */
   @property({ type: Number, attribute: 'slides-per-move' }) slidesPerMove = 1;
 
@@ -137,6 +137,13 @@ export default class SlCarousel extends ShoelaceElement {
       childList: true,
       subtree: true
     });
+  }
+
+  protected willUpdate(changedProperties: PropertyValueMap<SlCarousel> | Map<PropertyKey, unknown>): void {
+    // Ensure the slidesPerMove is never higher than the slidesPerPage
+    if (changedProperties.has('slidesPerMove') || changedProperties.has('slidesPerPage')) {
+      this.slidesPerMove = Math.min(this.slidesPerMove, this.slidesPerPage);
+    }
   }
 
   private getPageCount() {

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -239,7 +239,7 @@ export default class SlCarousel extends ShoelaceElement {
       this.initializeSlides();
     }
 
-    this.goToSlide(this.activeSlide);
+    this.requestUpdate();
   };
 
   @watch('loop', { waitUntilFirstUpdate: true })

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -144,7 +144,7 @@ export default class SlCarousel extends ShoelaceElement {
   }
 
   private getCurrentPage() {
-    return Math.floor(this.activeSlide / this.slidesPerMove);
+    return Math.ceil(this.activeSlide / this.slidesPerMove);
   }
 
   private canScrollNext(): boolean {
@@ -344,15 +344,7 @@ export default class SlCarousel extends ShoelaceElement {
    * @param behavior - The behavior used for scrolling.
    */
   previous(behavior: ScrollBehavior = 'smooth') {
-    let previousIndex = this.activeSlide || this.activeSlide - this.slidesPerMove;
-    let canSnap = false;
-
-    while (!canSnap && previousIndex > 0) {
-      previousIndex -= 1;
-      canSnap = Math.abs(previousIndex - this.slidesPerMove) % this.slidesPerMove === 0;
-    }
-
-    this.goToSlide(previousIndex, behavior);
+    this.goToSlide(this.activeSlide - this.slidesPerMove, behavior);
   }
 
   /**
@@ -401,7 +393,7 @@ export default class SlCarousel extends ShoelaceElement {
   }
 
   render() {
-    const { scrollController, slidesPerPage } = this;
+    const { scrollController, slidesPerMove } = this;
     const pagesCount = this.getPageCount();
     const currentPage = this.getCurrentPage();
     const prevEnabled = this.canScrollPrev();
@@ -483,7 +475,7 @@ export default class SlCarousel extends ShoelaceElement {
                       aria-selected="${isActive ? 'true' : 'false'}"
                       aria-label="${this.localize.term('goToSlide', index + 1, pagesCount)}"
                       tabindex=${isActive ? '0' : '-1'}
-                      @click=${() => this.goToSlide(index * slidesPerPage)}
+                      @click=${() => this.goToSlide(index * slidesPerMove)}
                       @keydown=${this.handleKeyDown}
                     ></button>
                   `;

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -140,19 +140,19 @@ export default class SlCarousel extends ShoelaceElement {
   }
 
   private getPageCount() {
-    return Math.ceil(this.getSlides().length / this.slidesPerPage);
+    return Math.ceil((this.getSlides().length - this.slidesPerPage) / this.slidesPerMove) + 1;
   }
 
   private getCurrentPage() {
-    return Math.floor(this.activeSlide / this.slidesPerPage);
+    return Math.floor(this.activeSlide / this.slidesPerMove);
   }
 
   private canScrollNext(): boolean {
-    return this.loop || this.activeSlide + this.slidesPerPage <= this.getSlides().length - 1;
+    return this.loop || this.getCurrentPage() < this.getPageCount() - 1;
   }
 
   private canScrollPrev(): boolean {
-    return this.loop || this.activeSlide > 0;
+    return this.loop || this.getCurrentPage() > 0;
   }
 
   /** @internal Gets all carousel items. */
@@ -215,13 +215,11 @@ export default class SlCarousel extends ShoelaceElement {
 
       // Scrolls to the original slide without animating, so the user won't notice that the position has changed
       this.goToSlide(clonePosition, 'auto');
-
-      return;
-    }
-
-    // Activate the first intersecting slide
-    if (firstIntersecting) {
-      this.activeSlide = slides.indexOf(firstIntersecting.target as SlCarouselItem);
+    } else if (firstIntersecting) {
+      // Update the current index based on the first visible slide
+      const slideIndex = slides.indexOf(firstIntersecting.target as SlCarouselItem);
+      // Set the index to the first "snappable" slide
+      this.activeSlide = Math.ceil(slideIndex / this.slidesPerMove) * this.slidesPerMove;
     }
   }
 
@@ -240,7 +238,8 @@ export default class SlCarousel extends ShoelaceElement {
     if (needsInitialization) {
       this.initializeSlides();
     }
-    this.requestUpdate();
+
+    this.goToSlide(this.activeSlide);
   };
 
   @watch('loop', { waitUntilFirstUpdate: true })
@@ -377,7 +376,7 @@ export default class SlCarousel extends ShoelaceElement {
     const slides = this.getSlides();
     const slidesWithClones = this.getSlides({ excludeClones: false });
 
-    // No need to to anything in case there are no items in the carousel
+    // No need to do anything in case there are no items in the carousel
     if (!slides.length) {
       return;
     }

--- a/src/components/carousel/carousel.test.ts
+++ b/src/components/carousel/carousel.test.ts
@@ -227,15 +227,25 @@ describe('<sl-carousel>', () => {
     });
 
     [
-      [7, 2, 1, 6],
-      [7, 2, 2, 4],
-      [5, 3, 2, 2],
-      [5, 3, 3, 2]
-    ].forEach(([slides, slidesPerPage, slidesPerMove, expected]) => {
-      it(`should display the correct ${expected} pages for ${slides} slides grouped by ${slidesPerPage} and scrolling by ${slidesPerMove}`, async () => {
+      [7, 2, 1, false, 6],
+      [5, 3, 3, false, 2],
+      [10, 2, 2, false, 5],
+      [7, 2, 1, true, 7],
+      [5, 3, 3, true, 2],
+      [10, 2, 2, true, 5]
+    ].forEach(([slides, slidesPerPage, slidesPerMove, loop, expected]: [number, number, number, boolean, number]) => {
+      it(`should display ${expected} pages for ${slides} slides grouped by ${slidesPerPage} and scrolled by ${slidesPerMove}${
+        loop ? ' (loop)' : ''
+      }`, async () => {
         // Arrange
         const el = await fixture<SlCarousel>(html`
-          <sl-carousel pagination navigation slides-per-page="${slidesPerPage}" slides-per-move="${slidesPerMove}">
+          <sl-carousel
+            pagination
+            navigation
+            slides-per-page="${slidesPerPage}"
+            slides-per-move="${slidesPerMove}"
+            ?loop=${loop}
+          >
             ${map(range(slides), i => html`<sl-carousel-item>${i}</sl-carousel-item>`)}
           </sl-carousel>
         `);

--- a/src/components/carousel/carousel.test.ts
+++ b/src/components/carousel/carousel.test.ts
@@ -1,6 +1,8 @@
 import '../../../dist/shoelace.js';
 import { clickOnElement } from '../../internal/test.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { map } from 'lit/directives/map.js';
+import { range } from 'lit/directives/range.js';
 import sinon from 'sinon';
 import type SlCarousel from './carousel.js';
 
@@ -222,6 +224,26 @@ describe('<sl-carousel>', () => {
 
       // Assert
       expect(el.scrollContainer.style.getPropertyValue('--slides-per-page').trim()).to.be.equal('2');
+    });
+
+    [
+      [7, 2, 1, 6],
+      [7, 2, 2, 4],
+      [5, 3, 2, 2],
+      [5, 3, 3, 2]
+    ].forEach(([slides, slidesPerPage, slidesPerMove, expected]) => {
+      it(`should display the correct ${expected} pages for ${slides} slides grouped by ${slidesPerPage} and scrolling by ${slidesPerMove}`, async () => {
+        // Arrange
+        const el = await fixture<SlCarousel>(html`
+          <sl-carousel pagination navigation slides-per-page="${slidesPerPage}" slides-per-move="${slidesPerMove}">
+            ${map(range(slides), i => html`<sl-carousel-item>${i}</sl-carousel-item>`)}
+          </sl-carousel>
+        `);
+
+        // Assert
+        const paginationItems = el.shadowRoot!.querySelectorAll('.carousel__pagination-item');
+        expect(paginationItems.length).to.equal(expected);
+      });
     });
   });
 

--- a/src/components/carousel/carousel.test.ts
+++ b/src/components/carousel/carousel.test.ts
@@ -226,31 +226,8 @@ describe('<sl-carousel>', () => {
   });
 
   describe('when `slides-per-move` attribute is provided', () => {
-    it('should set the granularity of snapping', async () => {
-      // Arrange
-      const expectedSnapGranularity = 2;
-      const el = await fixture<SlCarousel>(html`
-        <sl-carousel slides-per-move="${expectedSnapGranularity}">
-          <sl-carousel-item>Node 1</sl-carousel-item>
-          <sl-carousel-item>Node 2</sl-carousel-item>
-          <sl-carousel-item>Node 3</sl-carousel-item>
-          <sl-carousel-item>Node 4</sl-carousel-item>
-        </sl-carousel>
-      `);
-
-      // Act
-      await el.updateComplete;
-
-      // Assert
-      for (let i = 0; i < el.children.length; i++) {
-        const child = el.children[i] as HTMLElement;
-
-        if (i % expectedSnapGranularity === 0) {
-          expect(child.style.getPropertyValue('scroll-snap-align')).to.be.equal('');
-        } else {
-          expect(child.style.getPropertyValue('scroll-snap-align')).to.be.equal('none');
-        }
-      }
+    describe('and it is less than `slides-per-page`', () => {
+      // TODO
     });
   });
 

--- a/src/components/carousel/carousel.test.ts
+++ b/src/components/carousel/carousel.test.ts
@@ -262,7 +262,7 @@ describe('<sl-carousel>', () => {
       // Arrange
       const expectedSnapGranularity = 2;
       const el = await fixture<SlCarousel>(html`
-        <sl-carousel slides-per-move="${expectedSnapGranularity}">
+        <sl-carousel slides-per-page="${expectedSnapGranularity}" slides-per-move="${expectedSnapGranularity}">
           <sl-carousel-item>Node 1</sl-carousel-item>
           <sl-carousel-item>Node 2</sl-carousel-item>
           <sl-carousel-item>Node 3</sl-carousel-item>
@@ -344,6 +344,28 @@ describe('<sl-carousel>', () => {
         expect(expectedSlide).to.have.class('--in-view');
         expect(expectedSlide).to.be.visible;
       }
+    });
+
+    it('should not be possible to move by a number that is greater than the displayed number', async () => {
+      // Arrange
+      const expectedSlidesPerMove = 2;
+      const el = await fixture<SlCarousel>(html`
+        <sl-carousel slides-per-page="${expectedSlidesPerMove}">
+          <sl-carousel-item>Node 1</sl-carousel-item>
+          <sl-carousel-item>Node 2</sl-carousel-item>
+          <sl-carousel-item>Node 3</sl-carousel-item>
+          <sl-carousel-item>Node 4</sl-carousel-item>
+          <sl-carousel-item>Node 5</sl-carousel-item>
+          <sl-carousel-item>Node 6</sl-carousel-item>
+        </sl-carousel>
+      `);
+
+      // Act
+      el.slidesPerMove = 3;
+      await el.updateComplete;
+
+      // Assert
+      expect(el.slidesPerMove).to.be.equal(expectedSlidesPerMove);
     });
   });
 
@@ -558,7 +580,7 @@ describe('<sl-carousel>', () => {
       it('should scroll the carousel to the next slide', async () => {
         // Arrange
         const el = await fixture<SlCarousel>(html`
-          <sl-carousel slides-per-move="2">
+          <sl-carousel slides-per-page="2" slides-per-move="2">
             <sl-carousel-item>Node 1</sl-carousel-item>
             <sl-carousel-item>Node 2</sl-carousel-item>
             <sl-carousel-item>Node 3</sl-carousel-item>
@@ -578,7 +600,7 @@ describe('<sl-carousel>', () => {
       it('should scroll the carousel to the previous slide', async () => {
         // Arrange
         const el = await fixture<SlCarousel>(html`
-          <sl-carousel slides-per-move="2">
+          <sl-carousel slides-per-page="2" slides-per-move="2">
             <sl-carousel-item>Node 1</sl-carousel-item>
             <sl-carousel-item>Node 2</sl-carousel-item>
             <sl-carousel-item>Node 3</sl-carousel-item>

--- a/src/components/carousel/carousel.test.ts
+++ b/src/components/carousel/carousel.test.ts
@@ -226,8 +226,92 @@ describe('<sl-carousel>', () => {
   });
 
   describe('when `slides-per-move` attribute is provided', () => {
-    describe('and it is less than `slides-per-page`', () => {
-      // TODO
+    it('should set the granularity of snapping', async () => {
+      // Arrange
+      const expectedSnapGranularity = 2;
+      const el = await fixture<SlCarousel>(html`
+        <sl-carousel slides-per-move="${expectedSnapGranularity}">
+          <sl-carousel-item>Node 1</sl-carousel-item>
+          <sl-carousel-item>Node 2</sl-carousel-item>
+          <sl-carousel-item>Node 3</sl-carousel-item>
+          <sl-carousel-item>Node 4</sl-carousel-item>
+        </sl-carousel>
+      `);
+
+      // Act
+      await el.updateComplete;
+
+      // Assert
+      for (let i = 0; i < el.children.length; i++) {
+        const child = el.children[i] as HTMLElement;
+
+        if (i % expectedSnapGranularity === 0) {
+          expect(child.style.getPropertyValue('scroll-snap-align')).to.be.equal('');
+        } else {
+          expect(child.style.getPropertyValue('scroll-snap-align')).to.be.equal('none');
+        }
+      }
+    });
+
+    it('should be possible to move by the given number of slides at a time', async () => {
+      // Arrange
+      const el = await fixture<SlCarousel>(html`
+        <sl-carousel navigation slides-per-move="2" slides-per-page="2">
+          <sl-carousel-item>Node 1</sl-carousel-item>
+          <sl-carousel-item>Node 2</sl-carousel-item>
+          <sl-carousel-item class="expected">Node 3</sl-carousel-item>
+          <sl-carousel-item class="expected">Node 4</sl-carousel-item>
+          <sl-carousel-item>Node 5</sl-carousel-item>
+          <sl-carousel-item>Node 6</sl-carousel-item>
+        </sl-carousel>
+      `);
+      const expectedSlides = el.querySelectorAll('.expected')!;
+      const nextButton: HTMLElement = el.shadowRoot!.querySelector('.carousel__navigation-button--next')!;
+
+      // Act
+      await clickOnElement(nextButton);
+
+      await oneEvent(el.scrollContainer, 'scrollend');
+      await el.updateComplete;
+
+      // Assert
+      for (const expectedSlide of expectedSlides) {
+        expect(expectedSlide).to.have.class('--in-view');
+        expect(expectedSlide).to.be.visible;
+      }
+    });
+
+    it('should be possible to move by a number that is less than the displayed number', async () => {
+      // Arrange
+      const el = await fixture<SlCarousel>(html`
+        <sl-carousel navigation slides-per-move="1" slides-per-page="2">
+          <sl-carousel-item>Node 1</sl-carousel-item>
+          <sl-carousel-item>Node 2</sl-carousel-item>
+          <sl-carousel-item>Node 3</sl-carousel-item>
+          <sl-carousel-item>Node 4</sl-carousel-item>
+          <sl-carousel-item class="expected">Node 5</sl-carousel-item>
+          <sl-carousel-item class="expected">Node 6</sl-carousel-item>
+        </sl-carousel>
+      `);
+      const expectedSlides = el.querySelectorAll('.expected')!;
+      const nextButton: HTMLElement = el.shadowRoot!.querySelector('.carousel__navigation-button--next')!;
+
+      // Act
+      await clickOnElement(nextButton);
+      await clickOnElement(nextButton);
+      await clickOnElement(nextButton);
+      await clickOnElement(nextButton);
+      await clickOnElement(nextButton);
+      await clickOnElement(nextButton);
+
+      await oneEvent(el.scrollContainer, 'scrollend');
+      await el.updateComplete;
+
+      // Assert
+      for (const expectedSlide of expectedSlides) {
+        expect(expectedSlide).to.have.class('--in-view');
+        expect(expectedSlide).to.be.visible;
+      }
     });
   });
 

--- a/src/components/carousel/scroll-controller.ts
+++ b/src/components/carousel/scroll-controller.ts
@@ -108,7 +108,7 @@ export class ScrollController<T extends ScrollHost> implements ReactiveControlle
     });
   }
 
-  async handleDragEnd() {
+  handleDragEnd() {
     const host = this.host;
     const scrollContainer = host.scrollContainer;
 
@@ -125,13 +125,16 @@ export class ScrollController<T extends ScrollHost> implements ReactiveControlle
     scrollContainer.scrollTo({ left: startLeft, top: startTop, behavior: 'auto' });
     scrollContainer.scrollTo({ left: finalLeft, top: finalTop, behavior: prefersReducedMotion() ? 'auto' : 'smooth' });
 
-    if (startLeft !== finalLeft || startTop !== finalTop) {
-      await waitForEvent(scrollContainer, 'scrollend');
-    }
+    // Wait for scroll to be applied
+    requestAnimationFrame(async () => {
+      if (startLeft !== finalLeft || startTop !== finalTop) {
+        await waitForEvent(scrollContainer, 'scrollend');
+      }
 
-    scrollContainer.style.removeProperty('scroll-snap-type');
+      scrollContainer.style.removeProperty('scroll-snap-type');
 
-    this.dragging = false;
-    host.requestUpdate();
+      this.dragging = false;
+      host.requestUpdate();
+    });
   }
 }

--- a/src/components/carousel/scroll-controller.ts
+++ b/src/components/carousel/scroll-controller.ts
@@ -1,4 +1,3 @@
-import { debounce } from '../../internal/debounce.js';
 import { prefersReducedMotion } from '../../internal/animate.js';
 import { waitForEvent } from '../../internal/event.js';
 import type { ReactiveController, ReactiveElement } from 'lit';
@@ -12,7 +11,6 @@ interface ScrollHost extends ReactiveElement {
  */
 export class ScrollController<T extends ScrollHost> implements ReactiveController {
   private host: T;
-  private pointers = new Set();
 
   dragging = false;
   scrolling = false;
@@ -30,11 +28,10 @@ export class ScrollController<T extends ScrollHost> implements ReactiveControlle
     const scrollContainer = host.scrollContainer;
 
     scrollContainer.addEventListener('scroll', this.handleScroll, { passive: true });
+    scrollContainer.addEventListener('scrollend', this.handleScrollEnd, true);
     scrollContainer.addEventListener('pointerdown', this.handlePointerDown);
     scrollContainer.addEventListener('pointerup', this.handlePointerUp);
     scrollContainer.addEventListener('pointercancel', this.handlePointerUp);
-    scrollContainer.addEventListener('touchstart', this.handleTouchStart, { passive: true });
-    scrollContainer.addEventListener('touchend', this.handleTouchEnd);
   }
 
   hostDisconnected(): void {
@@ -42,11 +39,10 @@ export class ScrollController<T extends ScrollHost> implements ReactiveControlle
     const scrollContainer = host.scrollContainer;
 
     scrollContainer.removeEventListener('scroll', this.handleScroll);
+    scrollContainer.removeEventListener('scrollend', this.handleScrollEnd, true);
     scrollContainer.removeEventListener('pointerdown', this.handlePointerDown);
     scrollContainer.removeEventListener('pointerup', this.handlePointerUp);
     scrollContainer.removeEventListener('pointercancel', this.handlePointerUp);
-    scrollContainer.removeEventListener('touchstart', this.handleTouchStart);
-    scrollContainer.removeEventListener('touchend', this.handleTouchEnd);
   }
 
   handleScroll = () => {
@@ -54,35 +50,22 @@ export class ScrollController<T extends ScrollHost> implements ReactiveControlle
       this.scrolling = true;
       this.host.requestUpdate();
     }
-    this.handleScrollEnd();
   };
 
-  @debounce(100)
-  handleScrollEnd() {
-    if (!this.pointers.size) {
-      // If no pointer is active in the scroll area then the scroll has ended
+  handleScrollEnd = () => {
+    if (this.scrolling && !this.dragging) {
       this.scrolling = false;
-      this.host.scrollContainer.dispatchEvent(
-        new CustomEvent('scrollend', {
-          bubbles: false,
-          cancelable: false
-        })
-      );
       this.host.requestUpdate();
-    } else {
-      // otherwise let's wait a bit more
-      this.handleScrollEnd();
     }
-  }
+  };
 
   handlePointerDown = (event: PointerEvent) => {
+    // Do not handle drag for touch interactions as scroll is natively supported
     if (event.pointerType === 'touch') {
       return;
     }
 
-    this.pointers.add(event.pointerId);
-
-    const canDrag = this.mouseDragging && !this.dragging && event.button === 0;
+    const canDrag = this.mouseDragging && event.button === 0;
     if (canDrag) {
       event.preventDefault();
 
@@ -105,24 +88,9 @@ export class ScrollController<T extends ScrollHost> implements ReactiveControlle
   };
 
   handlePointerUp = (event: PointerEvent) => {
-    this.pointers.delete(event.pointerId);
     this.host.scrollContainer.releasePointerCapture(event.pointerId);
 
-    if (this.pointers.size === 0) {
-      this.handleDragEnd();
-    }
-  };
-
-  handleTouchEnd = (event: TouchEvent) => {
-    for (const touch of event.changedTouches) {
-      this.pointers.delete(touch.identifier);
-    }
-  };
-
-  handleTouchStart = (event: TouchEvent) => {
-    for (const touch of event.touches) {
-      this.pointers.add(touch.identifier);
-    }
+    this.handleDragEnd();
   };
 
   handleDragStart() {
@@ -140,12 +108,11 @@ export class ScrollController<T extends ScrollHost> implements ReactiveControlle
     });
   }
 
-  async handleDragEnd() {
+  handleDragEnd() {
     const host = this.host;
     const scrollContainer = host.scrollContainer;
 
     scrollContainer.removeEventListener('pointermove', this.handlePointerMove);
-    this.dragging = false;
 
     const startLeft = scrollContainer.scrollLeft;
     const startTop = scrollContainer.scrollTop;
@@ -158,12 +125,15 @@ export class ScrollController<T extends ScrollHost> implements ReactiveControlle
     scrollContainer.scrollTo({ left: startLeft, top: startTop, behavior: 'auto' });
     scrollContainer.scrollTo({ left: finalLeft, top: finalTop, behavior: prefersReducedMotion() ? 'auto' : 'smooth' });
 
-    if (this.scrolling) {
-      await waitForEvent(scrollContainer, 'scrollend');
-    }
+    requestAnimationFrame(async () => {
+      if (startLeft !== finalLeft || startTop !== finalTop) {
+        await waitForEvent(scrollContainer, 'scrollend');
+      }
 
-    scrollContainer.style.removeProperty('scroll-snap-type');
+      scrollContainer.style.removeProperty('scroll-snap-type');
 
-    host.requestUpdate();
+      this.dragging = false;
+      host.requestUpdate();
+    });
   }
 }

--- a/src/components/carousel/scroll-controller.ts
+++ b/src/components/carousel/scroll-controller.ts
@@ -108,7 +108,7 @@ export class ScrollController<T extends ScrollHost> implements ReactiveControlle
     });
   }
 
-  handleDragEnd() {
+  async handleDragEnd() {
     const host = this.host;
     const scrollContainer = host.scrollContainer;
 
@@ -125,15 +125,13 @@ export class ScrollController<T extends ScrollHost> implements ReactiveControlle
     scrollContainer.scrollTo({ left: startLeft, top: startTop, behavior: 'auto' });
     scrollContainer.scrollTo({ left: finalLeft, top: finalTop, behavior: prefersReducedMotion() ? 'auto' : 'smooth' });
 
-    requestAnimationFrame(async () => {
-      if (startLeft !== finalLeft || startTop !== finalTop) {
-        await waitForEvent(scrollContainer, 'scrollend');
-      }
+    if (startLeft !== finalLeft || startTop !== finalTop) {
+      await waitForEvent(scrollContainer, 'scrollend');
+    }
 
-      scrollContainer.style.removeProperty('scroll-snap-type');
+    scrollContainer.style.removeProperty('scroll-snap-type');
 
-      this.dragging = false;
-      host.requestUpdate();
-    });
+    this.dragging = false;
+    host.requestUpdate();
   }
 }

--- a/src/internal/scrollend-polyfill.ts
+++ b/src/internal/scrollend-polyfill.ts
@@ -43,7 +43,7 @@ if (!isSupported) {
   document.addEventListener('pointerdown', handlePointerDown);
   document.addEventListener('pointerup', handlePointerUp);
 
-  decorate(EventTarget.prototype, 'addEventListener', function (this: EventTarget, superFn, type) {
+  decorate(EventTarget.prototype, 'addEventListener', function (this: EventTarget, addEventListener, type) {
     if (type !== 'scroll') return;
 
     const handleScrollEnd = debounce(() => {
@@ -56,16 +56,16 @@ if (!isSupported) {
       }
     }, 100);
 
-    superFn.call(this, 'scroll', handleScrollEnd, { passive: true });
+    addEventListener.call(this, 'scroll', handleScrollEnd, { passive: true });
     scrollHandlers.set(this, handleScrollEnd);
   });
 
-  decorate(EventTarget.prototype, 'removeEventListener', function (this: EventTarget, superFn, type) {
+  decorate(EventTarget.prototype, 'removeEventListener', function (this: EventTarget, removeEventListener, type) {
     if (type !== 'scroll') return;
 
     const scrollHandler = scrollHandlers.get(this);
     if (scrollHandler) {
-      superFn.call(this, 'scroll', scrollHandler, { passive: true } as unknown as EventListenerOptions);
+      removeEventListener.call(this, 'scroll', scrollHandler, { passive: true } as unknown as EventListenerOptions);
     }
   });
 }

--- a/src/internal/scrollend-polyfill.ts
+++ b/src/internal/scrollend-polyfill.ts
@@ -1,0 +1,71 @@
+type GenericCallback = (this: unknown, ...args: unknown[]) => unknown;
+
+type MethodOf<T, K extends keyof T> = T[K] extends GenericCallback ? T[K] : never;
+
+const debounce = <T extends GenericCallback>(fn: T, delay: number) => {
+  let timerId = 0;
+
+  return function (this: unknown, ...args: unknown[]) {
+    window.clearTimeout(timerId);
+    timerId = window.setTimeout(() => {
+      fn.call(this, ...args);
+    }, delay);
+  };
+};
+
+const decorate = <T, M extends keyof T>(
+  proto: T,
+  method: M,
+  decorateFn: (this: unknown, superFn: T[M], ...args: unknown[]) => unknown
+) => {
+  const superFn = proto[method] as MethodOf<T, M>;
+
+  proto[method] = function (this: unknown, ...args: unknown[]) {
+    superFn.call(this, ...args);
+    decorateFn.call(this, superFn, ...args);
+  } as MethodOf<T, M>;
+};
+
+const isSupported = 'onscrollend' in window;
+
+if (!isSupported) {
+  const pointers = new Set();
+  const scrollHandlers = new WeakMap<EventTarget, EventListenerOrEventListenerObject>();
+
+  const handlePointerDown = (event: PointerEvent) => {
+    pointers.add(event.pointerId);
+  };
+
+  const handlePointerUp = (event: PointerEvent) => {
+    pointers.delete(event.pointerId);
+  };
+
+  document.addEventListener('pointerdown', handlePointerDown);
+  document.addEventListener('pointerup', handlePointerUp);
+
+  decorate(EventTarget.prototype, 'addEventListener', function (this: EventTarget, superFn, type) {
+    if (type !== 'scroll') return;
+
+    const handleScrollEnd = debounce(() => {
+      if (!pointers.size) {
+        // If no pointer is active in the scroll area then the scroll has ended
+        this.dispatchEvent(new Event('scrollend'));
+      } else {
+        // otherwise let's wait a bit more
+        handleScrollEnd();
+      }
+    }, 100);
+
+    superFn.call(this, 'scroll', handleScrollEnd, { passive: true });
+    scrollHandlers.set(this, handleScrollEnd);
+  });
+
+  decorate(EventTarget.prototype, 'removeEventListener', function (this: EventTarget, superFn, type) {
+    if (type !== 'scroll') return;
+
+    const scrollHandler = scrollHandlers.get(this);
+    if (scrollHandler) {
+      superFn.call(this, 'scroll', scrollHandler, { passive: true } as unknown as EventListenerOptions);
+    }
+  });
+}


### PR DESCRIPTION
This PR addresses an issue mentioned in #1546 where it was not possible to scroll to the last carousel item under certain circumstances, such as when the number of slides per move is less than the number of slides displayed.

The pagination logic has been updated as well so that is reflects the pagination more accurately. Before, the carousel displayed a number of pagination items based just on the displayed slide, regardless of the user's movement preference.

In addition to the fix, the scroll controller has been refactored, and the code for supporting scrollend has been moved to a separate file to implement a polyfill. This change was necessary because browsers have started to ship this feature, causing the event to be fired multiple times.
https://caniuse.com/?search=scrollend

fixes #1546 