### PR TITLE
Escape handler should not block event propagation on a disabled tooltip

### DIFF
--- a/src/components/tooltip/tooltip.component.ts
+++ b/src/components/tooltip/tooltip.component.ts
@@ -146,7 +146,10 @@ export default class SlTooltip extends ShoelaceElement {
   private handleKeyDown = (event: KeyboardEvent) => {
     // Pressing escape when the target element has focus should dismiss the tooltip
     if (this.open && event.key === 'Escape') {
-      event.stopPropagation();
+      if (!this.disabled) {
+        // Keyboard interactions should always propagate past a disabled (invisible) tooltip
+        event.stopPropagation();
+      }
       this.hide();
     }
   };


### PR DESCRIPTION
Hi folks!

A disabled tooltip is not shown to the user as the popup is never activated, hence the keyboard handler for the `Escape` key should not block event propagation.

This behaviour causes a UX issue where, if the tooltip wraps an element that has another `Escape` handler, the user has to press `Escape` twice to activate this handler, with the first press seemingly doing nothing [tooltip is disabled, but event propagation is stopped and hide() is called on an already invisible component]

This is just my way of making it work - feel free to suggest edits and discuss.