### PR TITLE
Fix `tabbable` performance issues in Chrome / Edge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@lit-labs/react": "^2.1.1",
         "@shoelace-style/animations": "^1.1.0",
         "@shoelace-style/localize": "^3.1.2",
-        "composed-offset-position": "^0.0.4",
         "lit": "^3.0.0",
         "qr-creator": "^1.0.0"
       },
@@ -6112,11 +6111,6 @@
       "engines": {
         "node": ">= 12.0.0"
       }
-    },
-    "node_modules/composed-offset-position": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
-      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw=="
     },
     "node_modules/compress-brotli": {
       "version": "1.3.8",
@@ -23193,11 +23187,6 @@
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.0.tgz",
       "integrity": "sha512-QLyTNiZ2KDOibvFPlZ6ZngVsZ/0gYnE6uTXi5aoDg8ed3AkJAz4sEje3Y8a29hQ1s6A99MZXe47fLAXQ1rTqaw==",
       "dev": true
-    },
-    "composed-offset-position": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
-      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw=="
     },
     "compress-brotli": {
       "version": "1.3.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@lit-labs/react": "^2.1.1",
         "@shoelace-style/animations": "^1.1.0",
         "@shoelace-style/localize": "^3.1.2",
+        "composed-offset-position": "^0.0.4",
         "lit": "^3.0.0",
         "qr-creator": "^1.0.0"
       },
@@ -6111,6 +6112,11 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/composed-offset-position": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
+      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw=="
     },
     "node_modules/compress-brotli": {
       "version": "1.3.8",
@@ -23187,6 +23193,11 @@
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.0.tgz",
       "integrity": "sha512-QLyTNiZ2KDOibvFPlZ6ZngVsZ/0gYnE6uTXi5aoDg8ed3AkJAz4sEje3Y8a29hQ1s6A99MZXe47fLAXQ1rTqaw==",
       "dev": true
+    },
+    "composed-offset-position": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
+      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw=="
     },
     "compress-brotli": {
       "version": "1.3.8",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "build": "node scripts/build.js",
     "verify": "npm run prettier:check && npm run lint && npm run build && npm run test",
     "prepublishOnly": "npm run verify",
-    "prettier": "prettier --write --loglevel warn .",
-    "prettier:check": "prettier --check --loglevel warn .",
+    "prettier": "prettier --write --log-level=warn .",
+    "prettier:check": "prettier --check --log-level=warn .",
     "lint": "eslint src --max-warnings 0",
     "lint:fix": "eslint src --max-warnings 0 --fix",
     "ts-check": "tsc --noEmit --project ./tsconfig.json",
@@ -72,6 +72,7 @@
     "@lit-labs/react": "^2.1.1",
     "@shoelace-style/animations": "^1.1.0",
     "@shoelace-style/localize": "^3.1.2",
+    "composed-offset-position": "^0.0.4",
     "lit": "^3.0.0",
     "qr-creator": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,8 +25,15 @@
     "./dist/react/*": "./dist/react/*",
     "./dist/translations/*": "./dist/translations/*"
   },
-  "files": ["dist", "cdn"],
-  "keywords": ["web components", "custom elements", "components"],
+  "files": [
+    "dist",
+    "cdn"
+  ],
+  "keywords": [
+    "web components",
+    "custom elements",
+    "components"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/shoelace-style/shoelace.git"
@@ -65,7 +72,6 @@
     "@lit-labs/react": "^2.1.1",
     "@shoelace-style/animations": "^1.1.0",
     "@shoelace-style/localize": "^3.1.2",
-    "composed-offset-position": "^0.0.4",
     "lit": "^3.0.0",
     "qr-creator": "^1.0.0"
   },
@@ -133,6 +139,9 @@
     "user-agent-data-types": "^0.3.1"
   },
   "lint-staged": {
-    "*.{ts,js}": ["eslint --max-warnings 0 --cache --fix", "prettier --write"]
+    "*.{ts,js}": [
+      "eslint --max-warnings 0 --cache --fix",
+      "prettier --write"
+    ]
   }
 }

--- a/src/internal/modal.ts
+++ b/src/internal/modal.ts
@@ -87,7 +87,7 @@ export default class Modal {
 
     if (currentFocusIndex === -1) {
       this.currentFocus = tabbableElements[0];
-      this.currentFocus.focus({ preventScroll: true });
+      this.currentFocus?.focus({ preventScroll: true });
       return;
     }
 

--- a/src/internal/tabbable.ts
+++ b/src/internal/tabbable.ts
@@ -1,5 +1,8 @@
-import { offsetParent } from 'composed-offset-position';
-
+// It doesn't technically check visibility, it checks if the element has been rendered and can maybe possibly be tabbed to.
+// This is a workaround for shadowroots not having an `offsetParent`
+function isTakingUpSpace (elem: HTMLElement): boolean {
+  return Boolean( elem.offsetParent || elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length );
+}
 /** Determines if the specified element is tabbable using heuristics inspired by https://github.com/focus-trap/tabbable */
 function isTabbable(el: HTMLElement) {
   const tag = el.tagName.toLowerCase();
@@ -20,8 +23,8 @@ function isTabbable(el: HTMLElement) {
   }
 
   // Elements that are hidden have no offsetParent and are not tabbable
-  // offsetParent() is added because otherwise it misses elements in Safari
-  if (el.offsetParent === null && offsetParent(el) === null) {
+  // !isRendered is added because otherwise it misses elements in Safari
+  if (!isTakingUpSpace(el)) {
     return false;
   }
 

--- a/src/internal/tabbable.ts
+++ b/src/internal/tabbable.ts
@@ -3,8 +3,8 @@
 // https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom
 // Previously, we used https://www.npmjs.com/package/composed-offset-position, but recursing up an entire
 // node tree took up a lot of CPU cycles and made focus traps unusable in Chrome / Edge.
-function isTakingUpSpace (elem: HTMLElement): boolean {
-  return Boolean( elem.offsetParent || elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length );
+function isTakingUpSpace(elem: HTMLElement): boolean {
+  return Boolean(elem.offsetParent || elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length);
 }
 /** Determines if the specified element is tabbable using heuristics inspired by https://github.com/focus-trap/tabbable */
 function isTabbable(el: HTMLElement) {

--- a/src/internal/tabbable.ts
+++ b/src/internal/tabbable.ts
@@ -1,5 +1,8 @@
 // It doesn't technically check visibility, it checks if the element has been rendered and can maybe possibly be tabbed to.
 // This is a workaround for shadowroots not having an `offsetParent`
+// https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom
+// Previously, we used https://www.npmjs.com/package/composed-offset-position, but recursing up an entire
+// node tree took up a lot of CPU cycles and made focus traps unusable in Chrome / Edge.
 function isTakingUpSpace (elem: HTMLElement): boolean {
   return Boolean( elem.offsetParent || elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length );
 }


### PR DESCRIPTION
Fixes #1612 

The TLDR is that a package we were relying on for checking `offsetParent` was recursing up the entire nodeTree calling `getComputedStyle` causing massive slow downs.

This PR replaces that expensive check with a much less expensive check of merely checking heights / widths. This may cause some unexpected behavior for non-typical use-cases, but it seems to be a better alternative than crashing browsers. It was testing with the following sandbox: 

EDIT:

Original (broken, 2.9.0) version: https://codepen.io/paramagicdev/pen/poqmMLb?editors=1100
PR (fixed) version: https://codepen.io/paramagicdev/pen/rNobeqE?editors=1100

And appeared to behave as expected.

