### PR TITLE
Update dependency of `@lit-labs/react` to official stable package `@lit/react`

### DIFF
--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -21,6 +21,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 - Fixed a bug in `<sl-menu>` that caused it not to fire the `sl-select` event if you clicked an element inside of a `<sl-menu-item>` [#1599]
 - Improved submenu selection by implementing the [safe triangle](https://www.smashingmagazine.com/2023/08/better-context-menus-safe-triangles/) method [#1550]
 - Updated `@shoelace-style/localize` to 3.1.0
+- Updated `@lib-labs/react` to stable `@lit/react`
 - Updated Bootstrap Icons to 1.11.1
 - Updated Lit to 3.0.0
 - Updated TypeScript to 5.2.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.2",
         "@floating-ui/dom": "^1.5.3",
-        "@lit-labs/react": "^2.1.1",
+        "@lit/react": "^1.0.0",
         "@shoelace-style/animations": "^1.1.0",
         "@shoelace-style/localize": "^3.1.2",
         "composed-offset-position": "^0.0.4",
@@ -1567,14 +1567,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
-      }
-    },
-    "node_modules/@lit-labs/react": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-2.1.1.tgz",
-      "integrity": "sha512-wr15ZOCZ7t2yB8UEfQ6oSRCmfxpIjhzDkN8DlgSOwsbJzWQTk8hxHRLy7Rra6mxrIajqvrMWQB2VskUU2uuoRA==",
-      "dependencies": {
-        "@lit/react": "1.0.0"
       }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
@@ -19694,14 +19686,6 @@
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
-      }
-    },
-    "@lit-labs/react": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-2.1.1.tgz",
-      "integrity": "sha512-wr15ZOCZ7t2yB8UEfQ6oSRCmfxpIjhzDkN8DlgSOwsbJzWQTk8hxHRLy7Rra6mxrIajqvrMWQB2VskUU2uuoRA==",
-      "requires": {
-        "@lit/react": "1.0.0"
       }
     },
     "@lit-labs/ssr-dom-shim": {

--- a/package.json
+++ b/package.json
@@ -25,15 +25,8 @@
     "./dist/react/*": "./dist/react/*",
     "./dist/translations/*": "./dist/translations/*"
   },
-  "files": [
-    "dist",
-    "cdn"
-  ],
-  "keywords": [
-    "web components",
-    "custom elements",
-    "components"
-  ],
+  "files": ["dist", "cdn"],
+  "keywords": ["web components", "custom elements", "components"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/shoelace-style/shoelace.git"
@@ -140,9 +133,6 @@
     "user-agent-data-types": "^0.3.1"
   },
   "lint-staged": {
-    "*.{ts,js}": [
-      "eslint --max-warnings 0 --cache --fix",
-      "prettier --write"
-    ]
+    "*.{ts,js}": ["eslint --max-warnings 0 --cache --fix", "prettier --write"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,15 @@
     "./dist/react/*": "./dist/react/*",
     "./dist/translations/*": "./dist/translations/*"
   },
-  "files": ["dist", "cdn"],
-  "keywords": ["web components", "custom elements", "components"],
+  "files": [
+    "dist",
+    "cdn"
+  ],
+  "keywords": [
+    "web components",
+    "custom elements",
+    "components"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/shoelace-style/shoelace.git"
@@ -62,7 +69,7 @@
   "dependencies": {
     "@ctrl/tinycolor": "^4.0.2",
     "@floating-ui/dom": "^1.5.3",
-    "@lit-labs/react": "^2.1.1",
+    "@lit/react": "^1.0.0",
     "@shoelace-style/animations": "^1.1.0",
     "@shoelace-style/localize": "^3.1.2",
     "composed-offset-position": "^0.0.4",
@@ -133,6 +140,9 @@
     "user-agent-data-types": "^0.3.1"
   },
   "lint-staged": {
-    "*.{ts,js}": ["eslint --max-warnings 0 --cache --fix", "prettier --write"]
+    "*.{ts,js}": [
+      "eslint --max-warnings 0 --cache --fix",
+      "prettier --write"
+    ]
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -87,7 +87,7 @@ async function buildTheDocs(watch = false) {
 // Builds the source with esbuild.
 //
 async function buildTheSource() {
-  const alwaysExternal = ['@lit-labs/react', 'react'];
+  const alwaysExternal = ['@lit/react', 'react'];
 
   const cdnConfig = {
     format: 'esm',
@@ -122,7 +122,7 @@ async function buildTheSource() {
     // We don't bundle certain dependencies in the unbundled build. This ensures we ship bare module specifiers,
     // allowing end users to better optimize when using a bundler. (Only packages that ship ESM can be external.)
     //
-    // We never bundle React or @lit-labs/react though!
+    // We never bundle React or @lit/react though!
     //
     external: alwaysExternal,
     splitting: true,

--- a/scripts/make-react.js
+++ b/scripts/make-react.js
@@ -31,8 +31,7 @@ components.forEach(async component => {
   const eventExports = (component.events || [])
     .map(event => `export type { ${event.eventName} } from '../../../src/events/events';`)
     .join('\n');
-  const eventNameImport =
-    (component.events || []).length > 0 ? `import { type EventName  } from '@lit-labs/react';` : ``;
+  const eventNameImport = (component.events || []).length > 0 ? `import { type EventName  } from '@lit/react';` : ``;
   const events = (component.events || [])
     .map(event => `${event.reactName}: '${event.name}' as EventName<${event.eventName}>`)
     .join(',\n');
@@ -44,7 +43,7 @@ components.forEach(async component => {
   const source = await prettier.format(
     `
       import * as React from 'react';
-      import { createComponent } from '@lit-labs/react';
+      import { createComponent } from '@lit/react';
       import Component from '../../${importPath}';
 
       ${eventNameImport}


### PR DESCRIPTION
Together with lit@3, lib-labs/react has reached stability and is now available via @lit/react. This PR updates Shoelace to use the new official package.