### PR TITLE
Update carousel.md to document the default aspect ratio of 16/9.

### DIFF
--- a/docs/pages/components/carousel.md
+++ b/docs/pages/components/carousel.md
@@ -803,7 +803,7 @@ const App = () => (
 
 ### Aspect Ratio
 
-Use the `--aspect-ratio` custom property to customize the size of the carousel's viewport.
+Use the `--aspect-ratio` custom property to customize the size of the carousel's viewport from the default value of `16/9`.
 
 ```html:preview
 <sl-carousel class="aspect-ratio" navigation pagination style="--aspect-ratio: 3/2;">


### PR DESCRIPTION
I only found the default aspect ratio of the carousel by digging into the source code and thought including it in the documentation would be helpful.