### PR TITLE
Don't block escape when tooltips are disabled

### DIFF
--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -15,6 +15,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 ## Next
 
 - Added the Croatian translation [#1656]
+- Fixed a bug that caused the [[Escape]] key to stop propagating when tooltips are disabled [#1607]
 
 ## 2.10.0
 

--- a/src/components/tooltip/tooltip.component.ts
+++ b/src/components/tooltip/tooltip.component.ts
@@ -145,7 +145,7 @@ export default class SlTooltip extends ShoelaceElement {
 
   private handleKeyDown = (event: KeyboardEvent) => {
     // Pressing escape when the target element has focus should dismiss the tooltip
-    if (this.open && event.key === 'Escape') {
+    if (this.open && !this.disabled && event.key === 'Escape') {
       event.stopPropagation();
       this.hide();
     }


### PR DESCRIPTION
Fixes #1607