### PR TITLE
docs: make usage of "filled" input more clear

### DIFF
--- a/docs/pages/components/input.md
+++ b/docs/pages/components/input.md
@@ -95,16 +95,16 @@ const App = () => <SlInput type="password" placeholder="Password Toggle" size="m
 
 ### Filled Inputs
 
-Add the `filled` attribute to draw a (pre-)filled input.
+Add the `filled` attribute to draw a filled input. This pairs especially well with `readonly`.
 
 ```html:preview
-<sl-input value="New York, NY" filled></sl-input>
+<sl-input value="New York, NY" filled readonly></sl-input>
 ```
 
 ```jsx:react
 import SlInput from '@shoelace-style/shoelace/dist/react/input';
 
-const App = () => <SlInput placeholder="Type something" filled />;
+const App = () => <SlInput placeholder=""New York, NY" filled readonly />;
 ```
 
 ### Disabled

--- a/docs/pages/components/input.md
+++ b/docs/pages/components/input.md
@@ -95,10 +95,10 @@ const App = () => <SlInput type="password" placeholder="Password Toggle" size="m
 
 ### Filled Inputs
 
-Add the `filled` attribute to draw a filled input.
+Add the `filled` attribute to draw a (pre-)filled input.
 
 ```html:preview
-<sl-input placeholder="Type something" filled></sl-input>
+<sl-input value="New York, NY" filled></sl-input>
 ```
 
 ```jsx:react


### PR DESCRIPTION
I finally realized the actual UX purpose of the "filled" input attribute.

1. I changed the docs to make it more clear, that this can be used for prefilled values.
2. For prefilled content it shouldn't show a placeholder, but actual content.