### PR TITLE
fix(carousel): add instance check to isCarouselItem

### DIFF
--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -235,8 +235,8 @@ export default class SlCarousel extends ShoelaceElement {
     }
   }
 
-  private isCarouselItem(node: HTMLElement): node is SlCarouselItem {
-    return node.tagName.toLowerCase() === 'sl-carousel-item';
+  private isCarouselItem(node: Node): node is SlCarouselItem {
+    return node instanceof Element && node.tagName.toLowerCase() === 'sl-carousel-item';
   }
 
   private handleSlotChange = (mutations: MutationRecord[]) => {


### PR DESCRIPTION
Adds a check in `isCarouselItem` to verify that the passed node is an instance of a Element.

This problem was found while investigating the issue https://github.com/shoelace-style/shoelace/issues/1683.
In that scenario the carousel was rendered using Lit, which during the render, appends comments nodes as placeholders. These nodes where detected by the mutation observer and passed to `isCarouselItem`, throwing the error `Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')`.
