### PR TITLE
Updates system copy button icon with Bootstrap Icons 1.11 `copy`

### DIFF
--- a/src/components/icon/library.system.ts
+++ b/src/components/icon/library.system.ts
@@ -41,8 +41,8 @@ const icons = {
     </svg>
   `,
   copy: `
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-files" viewBox="0 0 16 16" part="svg">
-      <path d="M13 0H6a2 2 0 0 0-2 2 2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h7a2 2 0 0 0 2-2 2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zm0 13V4a2 2 0 0 0-2-2H5a1 1 0 0 1 1-1h7a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1zM3 4a1 1 0 0 1 1-1h7a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V4z"></path>
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-copy" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V2Zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H6ZM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1H2Z"/>
     </svg>
   `,
   eye: `


### PR DESCRIPTION
### Context

Bootstrap Icons v1.11 finally has a[ real `copy` icon](https://icons.getbootstrap.com/icons/copy/)!  Currently Shoelace (alongside many others) uses `files` for this but I would hope this one is a better fit :)

### Changes
- Replaces the SVG with the updated `copy` icon in the system icon definitions.

### Screenshots

<img width="669" alt="Screenshot 2023-11-02 at 7 06 15 PM" src="https://github.com/shoelace-style/shoelace/assets/5672810/4059ad14-914b-49c8-83bb-efef68c81ae7">
