### PR TITLE
fix: make remove button in sl-tag focusable

### DIFF
--- a/src/components/tag/tag.component.ts
+++ b/src/components/tag/tag.component.ts
@@ -83,7 +83,6 @@ export default class SlTag extends ShoelaceElement {
                 label=${this.localize.term('remove')}
                 class="tag__remove"
                 @click=${this.handleRemoveClick}
-                tabindex="-1"
               ></sl-icon-button>
             `
           : ''}

--- a/src/components/tag/tag.test.ts
+++ b/src/components/tag/tag.test.ts
@@ -1,5 +1,6 @@
 import '../../../dist/shoelace.js';
 import { expect, fixture, html } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import type SlTag from './tag';
 
@@ -58,6 +59,19 @@ describe('<sl-tag>', () => {
       el.addEventListener('sl-remove', spy, { once: true });
 
       removeButton.click();
+
+      expect(spy.called).to.equal(true);
+    });
+
+    it('should be clickable via keyboard', async () => {
+      const el = await fixture<SlTag>(html` <sl-tag removable>Test</sl-tag> `);
+
+      const spy = sinon.spy();
+
+      el.addEventListener('sl-remove', spy, { once: true });
+
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ press: 'Enter' });
 
       expect(spy.called).to.equal(true);
     });


### PR DESCRIPTION
## Current behaviour

Remove buttons in tags are currently not reachable via keyboard, see https://shoelace.style/components/tag#removable

https://github.com/shoelace-style/shoelace/assets/26542182/feb68fa5-4724-44b9-b54b-04356080e242

## New behaviour

Remove buttons are reachable via keyboard, see https://shoelace-git-fork-mariohamann-next-font-awesome.vercel.app/components/tag#removable

https://github.com/shoelace-style/shoelace/assets/26542182/e96405c1-a087-4380-b96e-a7682491f1ec

As test is provided which fails before the change. I wanted to utilize window.activeElement but I believe it doesn't play well with ShadowDOM, so I went with the emit solution.