### PR TITLE
Fixes `setRangeText()` in `<sl-input>` and `<sl-textarea>`

### DIFF
--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -12,6 +12,10 @@ Components with the <sl-badge variant="warning" pill>Experimental</sl-badge> bad
 
 New versions of Shoelace are released as-needed and generally occur when a critical mass of changes have accumulated. At any time, you can see what's coming in the next release by visiting [next.shoelace.style](https://next.shoelace.style).
 
+## Next
+
+- Fixed a bug in `<sl-input>` and `<sl-textarea>` that made it work differently from `<input>` and `<textarea>` when using defaults [#1746]
+
 ## 2.12.0
 
 - Added the Italian translation [#1727]

--- a/src/components/input/input.component.ts
+++ b/src/components/input/input.component.ts
@@ -347,10 +347,12 @@ export default class SlInput extends ShoelaceElement implements ShoelaceFormCont
     replacement: string,
     start?: number,
     end?: number,
-    selectMode?: 'select' | 'start' | 'end' | 'preserve'
+    selectMode: 'select' | 'start' | 'end' | 'preserve' = 'preserve'
   ) {
-    // @ts-expect-error - start, end, and selectMode are optional
-    this.input.setRangeText(replacement, start, end, selectMode);
+    const selectionStart = start ?? this.input.selectionStart!;
+    const selectionEnd = end ?? this.input.selectionEnd!;
+
+    this.input.setRangeText(replacement, selectionStart, selectionEnd, selectMode);
 
     if (this.value !== this.input.value) {
       this.value = this.input.value;

--- a/src/components/input/input.test.ts
+++ b/src/components/input/input.test.ts
@@ -553,7 +553,6 @@ describe('<sl-input>', () => {
       el.setSelectionRange(1, 3);
       el.setRangeText('boom');
       await el.updateComplete;
-      console.log(el.value);
       expect(el.value).to.equal('tboomt'); // cspell:disable-line
     });
   });

--- a/src/components/input/input.test.ts
+++ b/src/components/input/input.test.ts
@@ -545,5 +545,18 @@ describe('<sl-input>', () => {
     });
   });
 
+  describe('when using the setRangeText() function', () => {
+    it('should set replacement text in the correct location', async () => {
+      const el = await fixture<SlInput>(html` <sl-input value="test"></sl-input> `);
+
+      el.focus();
+      el.setSelectionRange(1, 3);
+      el.setRangeText('boom');
+      await el.updateComplete;
+      console.log(el.value);
+      expect(el.value).to.equal('tboomt'); // cspell:disable-line
+    });
+  });
+
   runFormControlBaseTests('sl-input');
 });

--- a/src/components/textarea/textarea.component.ts
+++ b/src/components/textarea/textarea.component.ts
@@ -260,14 +260,12 @@ export default class SlTextarea extends ShoelaceElement implements ShoelaceFormC
     replacement: string,
     start?: number,
     end?: number,
-    selectMode?: 'select' | 'start' | 'end' | 'preserve'
+    selectMode: 'select' | 'start' | 'end' | 'preserve' = 'preserve'
   ) {
-    // @ts-expect-error - start, end, and selectMode are optional
-    this.input.setRangeText(replacement, start, end, selectMode);
+    const selectionStart = start; // ?? this.input.selectionStart;
+    const selectionEnd = end; // ?? this.input.selectionEnd;
 
-    if (this.value !== this.input.value) {
-      this.value = this.input.value;
-    }
+    this.input.setRangeText(replacement, selectionStart, selectionEnd, selectMode);
 
     if (this.value !== this.input.value) {
       this.value = this.input.value;

--- a/src/components/textarea/textarea.component.ts
+++ b/src/components/textarea/textarea.component.ts
@@ -262,8 +262,8 @@ export default class SlTextarea extends ShoelaceElement implements ShoelaceFormC
     end?: number,
     selectMode: 'select' | 'start' | 'end' | 'preserve' = 'preserve'
   ) {
-    const selectionStart = start; // ?? this.input.selectionStart;
-    const selectionEnd = end; // ?? this.input.selectionEnd;
+    const selectionStart = start ?? this.input.selectionStart;
+    const selectionEnd = end ?? this.input.selectionEnd;
 
     this.input.setRangeText(replacement, selectionStart, selectionEnd, selectMode);
 

--- a/src/components/textarea/textarea.test.ts
+++ b/src/components/textarea/textarea.test.ts
@@ -303,7 +303,6 @@ describe('<sl-textarea>', () => {
       el.setSelectionRange(1, 3);
       el.setRangeText('boom');
       await el.updateComplete;
-      console.log(el.value);
       expect(el.value).to.equal('tboomt'); // cspell:disable-line
     });
   });

--- a/src/components/textarea/textarea.test.ts
+++ b/src/components/textarea/textarea.test.ts
@@ -295,5 +295,18 @@ describe('<sl-textarea>', () => {
     });
   });
 
+  describe('when using the setRangeText() function', () => {
+    it('should set replacement text in the correct location', async () => {
+      const el = await fixture<SlTextarea>(html` <sl-textarea value="test"></sl-textarea> `);
+
+      el.focus();
+      el.setSelectionRange(1, 3);
+      el.setRangeText('boom');
+      await el.updateComplete;
+      console.log(el.value);
+      expect(el.value).to.equal('tboomt'); // cspell:disable-line
+    });
+  });
+
   runFormControlBaseTests('sl-textarea');
 });


### PR DESCRIPTION
See #1746 for details.