### PR TITLE
Add .d.ts files to theme style.js files

### DIFF
--- a/scripts/make-themes.js
+++ b/scripts/make-themes.js
@@ -47,9 +47,19 @@ files.forEach(async file => {
     { parser: 'babel-ts' }
   );
 
+  let dTs =  await prettier.format(
+    `
+    declare const _default: import("lit").CSSResult;
+    export default _default;
+  `,
+    { parser: 'babel-ts' }
+  );
+
   const cssFile = path.join(themesDir, path.basename(file));
   const jsFile = path.join(themesDir, path.basename(file).replace('.css', '.styles.js'));
+  const dTsFile = path.join(themesDir, path.basename(file).replace('.css', '.styles.d.ts'));
 
   fs.writeFileSync(cssFile, css, 'utf8');
   fs.writeFileSync(jsFile, js, 'utf8');
+  fs.writeFileSync(dTsFile, dTs, 'utf8');
 });


### PR DESCRIPTION
Add .d.ts definition files to the generated theme .style.js files: fixes #1762

Resolves the following error when importing themes:
```ts
import lightCss from '@shoelace-style/shoelace/dist/themes/light.styles.js';
//                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
// Cannot find module '@shoelace-style/shoelace/dist/themes/light.styles.js' or its corresponding type declarations.(2307)
```