### PR TITLE
internals: refactor stop animations resolve mechanism

### DIFF
--- a/src/internal/animate.ts
+++ b/src/internal/animate.ts
@@ -45,30 +45,8 @@ export function stopAnimations(el: HTMLElement) {
   return Promise.all(
     el.getAnimations().map(animation => {
       return new Promise(resolve => {
-        const requestId = requestAnimationFrame(timestamp => {
-          animation.oncancel = null;
-          animation.onfinish = null;
-          resolve(timestamp);
-        });
-
-        animation.addEventListener(
-          'cancel',
-          () => {
-            cancelAnimationFrame(requestId);
-            resolve('canceled');
-          },
-          { once: true }
-        );
-        animation.addEventListener(
-          'finish',
-          () => {
-            cancelAnimationFrame(requestId);
-            resolve('finished');
-          },
-          { once: true }
-        );
-        
         animation.cancel();
+        requestAnimationFrame(resolve);
       });
     })
   );

--- a/src/internal/animate.ts
+++ b/src/internal/animate.ts
@@ -45,10 +45,29 @@ export function stopAnimations(el: HTMLElement) {
   return Promise.all(
     el.getAnimations().map(animation => {
       return new Promise(resolve => {
-        const handleAnimationEvent = requestAnimationFrame(resolve);
+        const requestId = requestAnimationFrame(timestamp => {
+          animation.oncancel = null;
+          animation.onfinish = null;
+          resolve(timestamp);
+        });
 
-        animation.addEventListener('cancel', () => handleAnimationEvent, { once: true });
-        animation.addEventListener('finish', () => handleAnimationEvent, { once: true });
+        animation.addEventListener(
+          'cancel',
+          () => {
+            cancelAnimationFrame(requestId);
+            resolve('canceled');
+          },
+          { once: true }
+        );
+        animation.addEventListener(
+          'finish',
+          () => {
+            cancelAnimationFrame(requestId);
+            resolve('finished');
+          },
+          { once: true }
+        );
+        
         animation.cancel();
       });
     })


### PR DESCRIPTION
**This pull request is associated with [this issue](https://github.com/shoelace-style/shoelace/issues/1777) that refactors stopAnimations function.**

### Problem
In the current implementation of stopAnimations, the event listeners for cancel and finish are not doing anything particular regarding promise resolution and are just returning a variable named handleAnimationEvent that is the result of requestAnimationFrame call, which based on the [documentation ](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame#return_value) is an ID that we can use to cancel animation frame request.

### Solution
The changes made will make sure that if the animation is canceled or finished before the requestAnimationFrame callback is called then it will resolve the promise and will call cancelAnimationFrame with the requestId.

Or when the browser is about to repaint and none of the cancel or finish events were fired then the requestAnimationFrame callback is called, the event listeners are removed and the promise will get resolved before the repaint.


