### PR TITLE
improves form serialize

### DIFF
--- a/src/utilities/form.ts
+++ b/src/utilities/form.ts
@@ -8,18 +8,18 @@ export function serialize(form: HTMLFormElement) {
   const formData = new FormData(form);
   const object: Record<string, unknown> = {};
 
-	for (const [key, value] of formData) {
-		if (Object.hasOwn(object, key)) {
-			const entry = object[key]
-			if (Array.isArray(entry)) {
-				entry.push(value)
-			} else {
-				object[key] = [object[key], value]
-			}
-		} else {
-			object[key] = value
-		}
-	}
+  for (const [key, value] of formData) {
+    if (Object.hasOwn(object, key)) {
+      const entry = object[key]
+      if (Array.isArray(entry)) {
+        entry.push(value)
+      } else {
+        object[key] = [object[key], value]
+      }
+    } else {
+      object[key] = value
+    }
+  }
 
   return object;
 }

--- a/src/utilities/form.ts
+++ b/src/utilities/form.ts
@@ -10,14 +10,14 @@ export function serialize(form: HTMLFormElement) {
 
   for (const [key, value] of formData) {
     if (Object.hasOwn(object, key)) {
-      const entry = object[key]
+      const entry = object[key];
       if (Array.isArray(entry)) {
-        entry.push(value)
+        entry.push(value);
       } else {
-        object[key] = [object[key], value]
+        object[key] = [object[key], value];
       }
     } else {
-      object[key] = value
+      object[key] = value;
     }
   }
 

--- a/src/utilities/form.ts
+++ b/src/utilities/form.ts
@@ -8,18 +8,18 @@ export function serialize(form: HTMLFormElement) {
   const formData = new FormData(form);
   const object: Record<string, unknown> = {};
 
-  formData.forEach((value, key) => {
-    if (Reflect.has(object, key)) {
-      const entry = object[key];
-      if (Array.isArray(entry)) {
-        entry.push(value);
-      } else {
-        object[key] = [object[key], value];
-      }
-    } else {
-      object[key] = value;
-    }
-  });
+	for (const [key, value] of formData) {
+		if (Object.hasOwn(object, key)) {
+			const entry = object[key]
+			if (Array.isArray(entry)) {
+				entry.push(value)
+			} else {
+				object[key] = [object[key], value]
+			}
+		} else {
+			object[key] = value
+		}
+	}
 
   return object;
 }


### PR DESCRIPTION
1.  Replace `Reflect.has` for `Object.hasOwn` so the prototype isn't copied as a form value when the form field name matches a key from the prototype, (ie: object[key] = [Object.constructor, 'Bob The Builder']). Uses  `Object.hasOwn`  instead of `o.hasOwnProperty` in case you change the object to `Object.create(null)`
2. Changes `forEach` for `for of`, this may be just a preference, but is a good practice to try to not create closures that also access parent objects.