### PR TITLE
Add checkbox help text

### DIFF
--- a/docs/pages/components/checkbox.md
+++ b/docs/pages/components/checkbox.md
@@ -89,6 +89,20 @@ const App = () => (
 );
 ```
 
+### Help Text
+
+Add descriptive help text to a switch with the `help-text` attribute. For help texts that contain HTML, use the `help-text` slot instead.
+
+```html:preview
+<sl-checkbox help-text="What should the user know about the checkbox?">Label</sl-checkbox>
+```
+
+```jsx:react
+import SlCheckbox from '@shoelace-style/shoelace/dist/react/checkbox';
+
+const App = () => <SlCheckbox help-text="What should the user know about the switch?">Label</SlCheckbox>;
+```
+
 ### Custom Validity
 
 Use the `setCustomValidity()` method to set a custom validation message. This will prevent the form from submitting and make the browser display the error message you provide. To clear the error, call this function with an empty string.

--- a/docs/pages/components/switch.md
+++ b/docs/pages/components/switch.md
@@ -84,6 +84,8 @@ Add descriptive help text to a switch with the `help-text` attribute. For help t
 ```
 
 ```jsx:react
+import SlSwitch from '@shoelace-style/shoelace/dist/react/checkbox';
+
 const App = () => <SlSwitch help-text="What should the user know about the switch?">Label</SlSwitch>;
 ```
 

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -18,6 +18,8 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 
 ## 2.13.1
 
+- Added help text to `<sl-checkbox>`
+- Added help text to `<sl-switch>` [#1800]
 - Fixed a bug where the safe triangle was always visible when selecting nested `<sl-menu>` elements [#1835]
 
 ## 2.13.0

--- a/src/components/checkbox/checkbox.styles.ts
+++ b/src/components/checkbox/checkbox.styles.ts
@@ -1,8 +1,10 @@
 import { css } from 'lit';
 import componentStyles from '../../styles/component.styles.js';
+import formControlStyles from '../../styles/form-control.styles.js';
 
 export default css`
   ${componentStyles}
+  ${formControlStyles}
 
   :host {
     display: inline-block;

--- a/src/components/checkbox/checkbox.test.ts
+++ b/src/components/checkbox/checkbox.test.ts
@@ -23,6 +23,7 @@ describe('<sl-checkbox>', () => {
     expect(el.checked).to.be.false;
     expect(el.indeterminate).to.be.false;
     expect(el.defaultChecked).to.be.false;
+    expect(el.helpText).to.equal('');
   });
 
   it('should have title if title attribute is set', async () => {


### PR DESCRIPTION
Adds the same help text attr/slot to `<sl-checkbox>` as done to `<sl-switch>` in #1800.