### PR TITLE
Don't install playwright for dependent packages; fixes #1865

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "start": "node scripts/build.js --serve",
     "build": "node scripts/build.js",
     "verify": "npm run prettier:check && npm run lint && npm run build && npm run test",
-    "postinstall": "npx playwright install",
+    "prepare": "npx playwright install",
     "prepublishOnly": "npm run verify",
     "prettier": "prettier --write --log-level=warn .",
     "prettier:check": "prettier --check --log-level=warn .",


### PR DESCRIPTION
Closes #1865