### PR TITLE
update install event from `postinstall` to `prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "start": "node scripts/build.js --serve",
     "build": "node scripts/build.js",
     "verify": "npm run prettier:check && npm run lint && npm run build && npm run test",
-    "postinstall": "npx playwright install",
+    "prepare": "npx playwright install",
     "prepublishOnly": "npm run verify",
     "prettier": "prettier --write --log-level=warn .",
     "prettier:check": "prettier --check --log-level=warn .",


### PR DESCRIPTION
When users install Shoelace, they are also installing playwright because of the command in the `postinstall` script. To prevent this from happening, the script was changed to `prepare`. This event should execute after the install, but only locally for this project.

Fixes #1867 