### PR TITLE
Remove the trailing space when a sl-tooltip is used inline.

### DIFF
--- a/docs/pages/components/tooltip.md
+++ b/docs/pages/components/tooltip.md
@@ -26,6 +26,13 @@ const App = () => (
 );
 ```
 
+Tooltips also won't add extra spaces when used as inline elements.
+
+```html:preview
+The bold p<sl-tooltip content="This is a tooltip"><b>art of this
+sen</b></sl-tooltip>tence has a tooltip.
+```
+
 ## Examples
 
 ### Placement

--- a/src/components/popup/popup.component.ts
+++ b/src/components/popup/popup.component.ts
@@ -539,18 +539,13 @@ export default class SlPopup extends ShoelaceElement {
   };
 
   render() {
-    return html`
-      <slot name="anchor" @slotchange=${this.handleAnchorChange}></slot>
-
-      <span
+    return html`<slot name="anchor" @slotchange=${this.handleAnchorChange}></slot><span
         part="hover-bridge"
         class=${classMap({
           'popup-hover-bridge': true,
           'popup-hover-bridge--visible': this.hoverBridge && this.active
         })}
-      ></span>
-
-      <div
+      ></span><div
         part="popup"
         class=${classMap({
           popup: true,
@@ -558,10 +553,7 @@ export default class SlPopup extends ShoelaceElement {
           'popup--fixed': this.strategy === 'fixed',
           'popup--has-arrow': this.arrow
         })}
-      >
-        <slot></slot>
-        ${this.arrow ? html`<div part="arrow" class="popup__arrow" role="presentation"></div>` : ''}
-      </div>
-    `;
+      ><slot></slot
+      >${this.arrow ? html`<div part="arrow" class="popup__arrow" role="presentation"></div>` : ''}</div>`;
   }
 }

--- a/src/components/tooltip/tooltip.component.ts
+++ b/src/components/tooltip/tooltip.component.ts
@@ -260,8 +260,7 @@ export default class SlTooltip extends ShoelaceElement {
   // element, otherwise positioning is incorrect.
   //
   render() {
-    return html`
-      <sl-popup
+    return html`<sl-popup
         part="base"
         exportparts="
           popup:base__popup,
@@ -279,16 +278,11 @@ export default class SlTooltip extends ShoelaceElement {
         shift
         arrow
         hover-bridge
-      >
-        ${'' /* eslint-disable-next-line lit-a11y/no-aria-slot */}
-        <slot slot="anchor" aria-describedby="tooltip"></slot>
-
-        ${'' /* eslint-disable-next-line lit-a11y/accessible-name */}
-        <div part="body" id="tooltip" class="tooltip__body" role="tooltip" aria-live=${this.open ? 'polite' : 'off'}>
+      >${'' /* eslint-disable-next-line lit-a11y/no-aria-slot */
+      }<slot slot="anchor" aria-describedby="tooltip"></slot>${'' /* eslint-disable-next-line lit-a11y/accessible-name */
+      }<div part="body" id="tooltip" class="tooltip__body" role="tooltip" aria-live=${this.open ? 'polite' : 'off'}>
           <slot name="content">${this.content}</slot>
-        </div>
-      </sl-popup>
-    `;
+        </div></sl-popup>`;
   }
 }
 


### PR DESCRIPTION
This would fix #1866, but I'm sure you'd prefer some other style for avoiding spaces inside the <code>html``</code> strings. Feel free to explain how I should reformat or just take over the change and do it the right way yourself, whichever's easier for you. :)