### PR TITLE
feat(sl-popup): Add contextElement property to VirtualElement interface

### DIFF
--- a/docs/pages/components/popup.md
+++ b/docs/pages/components/popup.md
@@ -1839,3 +1839,15 @@ const App = () => {
   );
 };
 ```
+
+Sometimes the `getBoundingClientRects` might be derived from a real element. In this case provide the anchor element as context to ensure clipping and position updates for the popup work well.
+
+```ts
+const virtualElement = {
+  getBoundingClientRect() {
+    // ...
+    return { width, height, x, y, top, left, right, bottom };
+  },
+  contextElement: anchorElement
+};
+```

--- a/src/components/popup/popup.component.ts
+++ b/src/components/popup/popup.component.ts
@@ -10,10 +10,11 @@ import type { CSSResultGroup } from 'lit';
 
 export interface VirtualElement {
   getBoundingClientRect: () => DOMRect;
+  contextElement?: Element;
 }
 
 function isVirtualElement(e: unknown): e is VirtualElement {
-  return e !== null && typeof e === 'object' && 'getBoundingClientRect' in e;
+  return e !== null && typeof e === 'object' && 'getBoundingClientRect' in e && ('contextElement' in e ? e instanceof Element : true);
 }
 
 /**


### PR DESCRIPTION
As mentioned in the Discord channel:

In case of using a VirtualElement in sl-popup but having a real anchor element from which the getBoundingClientRects get derived, autoUpdate won't work correctly. You need to provide the anchor element as "contextElement".

See: https://floating-ui.com/docs/virtual-elements#contextelement

Feel free to re-model the change request so it fit's your style.