### PR TITLE
Revert sl-select 'keydown' and 'mousedown' events to document

### DIFF
--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -236,15 +236,15 @@ export default class SlSelect extends ShoelaceElement implements ShoelaceFormCon
       };
     }
     root.addEventListener('focusin', this.handleDocumentFocusIn);
-    root.addEventListener('keydown', this.handleDocumentKeyDown);
-    root.addEventListener('mousedown', this.handleDocumentMouseDown);
+    document.addEventListener('keydown', this.handleDocumentKeyDown);
+    document.addEventListener('mousedown', this.handleDocumentMouseDown);
   }
 
   private removeOpenListeners() {
     const root = this.getRootNode();
     root.removeEventListener('focusin', this.handleDocumentFocusIn);
-    root.removeEventListener('keydown', this.handleDocumentKeyDown);
-    root.removeEventListener('mousedown', this.handleDocumentMouseDown);
+    document.removeEventListener('keydown', this.handleDocumentKeyDown);
+    document.removeEventListener('mousedown', this.handleDocumentMouseDown);
     this.closeWatcher?.destroy();
   }
 


### PR DESCRIPTION
Basically this reverts the 'mousedown' and 'keydown' event listeners to `document` instead of `rootNode`.
I was not able to create a test for this unfortunately since I don't know how to test it inside shadowDOM.

Fixes #1859