### PR TITLE
fix `sl-rating` sometimes not resetting correctly when using `precisi…

### DIFF
--- a/src/components/rating/rating.component.ts
+++ b/src/components/rating/rating.component.ts
@@ -264,7 +264,6 @@ export default class SlRating extends ShoelaceElement {
                     'rating__symbol--hover': this.isHovering && Math.ceil(displayValue) === index + 1
                   })}
                   role="presentation"
-                  @mouseenter=${this.handleMouseEnter}
                 >
                   <div
                     style=${styleMap({
@@ -297,7 +296,6 @@ export default class SlRating extends ShoelaceElement {
                   'rating__symbol--active': displayValue >= index + 1
                 })}
                 role="presentation"
-                @mouseenter=${this.handleMouseEnter}
               >
                 ${unsafeHTML(this.getSymbol(index + 1))}
               </span>

--- a/src/components/rating/rating.styles.ts
+++ b/src/components/rating/rating.styles.ts
@@ -57,6 +57,7 @@ export default css`
 
   .rating__symbol {
     transition: var(--sl-transition-fast) scale;
+    pointer-events: none;
   }
 
   .rating__symbol--hover {


### PR DESCRIPTION
PR for #1802.

I think the both event handlers `@mouseenter` aren't needed as the base element already has one.
However only removing the event handlers didn't do the trick for me but adding `pointer-events` did.

I don't know why that is but here's a hypothesis:
- The rating elements are the ones that get swapped out when fiddling with the mouse.
- By disabling the pointer events for them the mouse has no interaction with them.
- Therefore entering and leaving the mouse only gets handled by the parent element which never gets removed.