### PR TITLE
fix form selection when element is detached (#1806)

### DIFF
--- a/src/internal/form.ts
+++ b/src/internal/form.ts
@@ -72,9 +72,8 @@ export class FormControlController implements ReactiveController {
         const formId = input.form;
 
         if (formId) {
-          const root = input.getRootNode() as Document | ShadowRoot;
-
-          const form = root.getElementById(formId);
+          const root = input.getRootNode() as Document | ShadowRoot | HTMLElement;
+          const form = root.querySelector(`#${formId}`);
 
           if (form) {
             return form as HTMLFormElement;


### PR DESCRIPTION
In #1806 the problem is that `getElementById()` only exists on document level but `getRootNode()` returns a `<div>` because the button isn't attached to any document anymore.

I don't know whether this fix is sufficient as it doesn't contain any escaping for the selector and also no adjusted tests.