### PR TITLE
fix:fix multi-select tag not changing with size

### DIFF
--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -617,7 +617,7 @@ export default class SlSelect extends ShoelaceElement implements ShoelaceFormCon
         </div>`;
       } else if (index === this.maxOptionsVisible) {
         // Hit tag limit
-        return html`<sl-tag>+${this.selectedOptions.length - index}</sl-tag>`;
+        return html`<sl-tag size=${this.size}>+${this.selectedOptions.length - index}</sl-tag>`;
       }
       return html``;
     });


### PR DESCRIPTION
This is my first PR submission to github, I would like to contribute a little bit to the open source project, please let me know if there are any problems! I found a small bug when using this ui library, when the size changes the tag behind it doesn't change!
<img width="789" alt="image-20240222163815872" src="https://github.com/shoelace-style/shoelace/assets/50167909/1a64f1d1-9a3d-47ce-bccb-e2655ea344c6">
