### PR TITLE
sl-multi-range component

### DIFF
--- a/docs/pages/components/multi-range.md
+++ b/docs/pages/components/multi-range.md
@@ -17,33 +17,6 @@ const App = () => <SlRange />;
 
 ## Examples
 
-### Custom Track Colors
-
-You can customize the active and inactive portions of the track using the `--track-color-active` and `--track-color-inactive` custom properties.
-
-```html:preview
-<sl-multi-range
-	value="[25,75]"
-	style="
-		--track-color-active: var(--sl-color-primary-300);
-		--track-color-inactive: var(--sl-color-neutral-200);
-	"
-></sl-multi-range>
-```
-
-{% raw %}
-
-```jsx:react
-import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
-
-const App = () => <SlRange value={[25,75]} style={{
-	'--track-color-active': 'var(--sl-color-primary-300)',
-	'--track-color-inactive': 'var(--sl-color-neutral-200)'
-}}/>;
-```
-
-{% endraw %}
-
 ### Min, Max, and Step
 
 Use the `min` and `max` attributes to set the range's minimum and maximum values, respectively. The `step` attribute determines the value's interval when increasing and decreasing.
@@ -81,13 +54,7 @@ const App = () => <SlRange disabled />;
 You can use any number of handles on the slider. The slider will have one handle for every element in the value array.
 
 ```html:preview
-<sl-multi-range
-	value="[25,50,75]"
-	style="
-		--track-color-active: var(--sl-color-primary-300);
-		--track-color-inactive: var(--sl-color-neutral-200);
-	"
-></sl-multi-range>
+<sl-multi-range value="[25,50,75]"></sl-multi-range>
 ```
 
 {% raw %}
@@ -95,10 +62,7 @@ You can use any number of handles on the slider. The slider will have one handle
 ```jsx:react
 import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
 
-const App = () => <SlRange value={[25,50,75]} style={{
-	'--track-color-active': 'var(--sl-color-primary-300)',
-	'--track-color-inactive': 'var(--sl-color-neutral-200)'
-}}/>;
+const App = () => <SlRange value={[25,50,75]} />;
 ```
 
 {% endraw %}
@@ -116,3 +80,30 @@ import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
 
 const App = () => <SlRange label="Difficulty Range" help-text"Search for challenges within the desired difficulty range" />;
 ```
+
+### Custom Track Colors
+
+You can customize the active and inactive portions of the track using the `--track-color-active` and `--track-color-inactive` custom properties.
+
+```html:preview
+<sl-multi-range
+	value="[25,75]"
+	style="
+		--track-color-active: var(--sl-color-green-300);
+		--track-color-inactive: var(--sl-color-red-300);
+	"
+></sl-multi-range>
+```
+
+{% raw %}
+
+```jsx:react
+import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
+
+const App = () => <SlRange value={[25,75]} style={{
+	'--track-color-active': 'var(--sl-color-green-300)',
+	'--track-color-inactive': 'var(--sl-color-red-300)'
+}}/>;
+```
+
+{% endraw %}

--- a/docs/pages/components/multi-range.md
+++ b/docs/pages/components/multi-range.md
@@ -22,7 +22,7 @@ const App = () => <SlRange />;
 Use the `min` and `max` attributes to set the range's minimum and maximum values, respectively. The `step` attribute determines the value's interval when increasing and decreasing.
 
 ```html:preview
-<sl-multi-range min="1" max="10" step="1" value="[0,10]"></sl-multi-range>
+<sl-multi-range min="1" max="10" step="1" value="0,10"></sl-multi-range>
 ```
 
 {% raw %}
@@ -54,7 +54,7 @@ const App = () => <SlRange disabled />;
 You can use any number of handles on the slider. The slider will have one handle for every element in the value array.
 
 ```html:preview
-<sl-multi-range value="[25,50,75]"></sl-multi-range>
+<sl-multi-range value="25,50,75"></sl-multi-range>
 ```
 
 {% raw %}
@@ -78,7 +78,7 @@ You can add an accessible label and/or descriptive help text using the `label` a
 ```jsx:react
 import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
 
-const App = () => <SlRange label="Difficulty Range" help-text"Search for challenges within the desired difficulty range" />;
+const App = () => <SlRange label="Difficulty Range" help-text="Search for challenges within the desired difficulty range" />;
 ```
 
 ### Custom Track Colors
@@ -87,7 +87,7 @@ You can customize the active and inactive portions of the track using the `--tra
 
 ```html:preview
 <sl-multi-range
-	value="[25,75]"
+	value="25,75"
 	style="
 		--track-color-active: var(--sl-color-green-300);
 		--track-color-inactive: var(--sl-color-red-300);

--- a/docs/pages/components/multi-range.md
+++ b/docs/pages/components/multi-range.md
@@ -30,7 +30,7 @@ Use the `min` and `max` attributes to set the range's minimum and maximum values
 ```jsx:react
 import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
 
-const App = () => <SlRange min={1} max={10} step={1} value={[0,10]}/>;
+const App = () => <SlRange min={1} max={10} step={1} value={'0,10'}/>;
 ```
 
 {% endraw %}
@@ -62,7 +62,7 @@ You can use any number of handles on the slider. The slider will have one handle
 ```jsx:react
 import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
 
-const App = () => <SlRange value={[25,50,75]} />;
+const App = () => <SlRange value={'25,50,75'} />;
 ```
 
 {% endraw %}
@@ -100,7 +100,7 @@ You can customize the active and inactive portions of the track using the `--tra
 ```jsx:react
 import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
 
-const App = () => <SlRange value={[25,75]} style={{
+const App = () => <SlRange value={'25,75'} style={{
 	'--track-color-active': 'var(--sl-color-green-300)',
 	'--track-color-inactive': 'var(--sl-color-red-300)'
 }}/>;

--- a/docs/pages/components/multi-range.md
+++ b/docs/pages/components/multi-range.md
@@ -102,3 +102,17 @@ const App = () => <SlRange value={[25,50,75]} style={{
 ```
 
 {% endraw %}
+
+### Label and Help Text
+
+You can add an accessible label and/or descriptive help text using the `label` and `help-text` attributes or slots.
+
+```html:preview
+<sl-multi-range label="Difficulty Range" help-text="Search for challenges within the desired difficulty range"></sl-multi-range>
+```
+
+```jsx:react
+import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
+
+const App = () => <SlRange label="Difficulty Range" help-text"Search for challenges within the desired difficulty range" />;
+```

--- a/docs/pages/components/multi-range.md
+++ b/docs/pages/components/multi-range.md
@@ -1,0 +1,104 @@
+---
+meta:
+  title: Multi-Range
+  description: Multi-Ranges allow the user to select multiple values within a given range using a slider with multiple handles.
+layout: component
+---
+
+```html:preview
+<sl-multi-range></sl-multi-range>
+```
+
+```jsx:react
+import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
+
+const App = () => <SlRange />;
+```
+
+## Examples
+
+### Custom Track Colors
+
+You can customize the active and inactive portions of the track using the `--track-color-active` and `--track-color-inactive` custom properties.
+
+```html:preview
+<sl-multi-range
+	value="[25,75]"
+	style="
+		--track-color-active: var(--sl-color-primary-300);
+		--track-color-inactive: var(--sl-color-neutral-200);
+	"
+></sl-multi-range>
+```
+
+{% raw %}
+
+```jsx:react
+import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
+
+const App = () => <SlRange value={[25,75]} style={{
+	'--track-color-active': 'var(--sl-color-primary-300)',
+	'--track-color-inactive': 'var(--sl-color-neutral-200)'
+}}/>;
+```
+
+{% endraw %}
+
+### Min, Max, and Step
+
+Use the `min` and `max` attributes to set the range's minimum and maximum values, respectively. The `step` attribute determines the value's interval when increasing and decreasing.
+
+```html:preview
+<sl-multi-range min="1" max="10" step="1" value="[0,10]"></sl-multi-range>
+```
+
+{% raw %}
+
+```jsx:react
+import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
+
+const App = () => <SlRange min={1} max={10} step={1} value={[0,10]}/>;
+```
+
+{% endraw %}
+
+### Disabled
+
+Use the `disabled` attribute to disable a slider.
+
+```html:preview
+<sl-multi-range disabled></sl-multi-range>
+```
+
+```jsx:react
+import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
+
+const App = () => <SlRange disabled />;
+```
+
+### Arbitrary Number of Handles
+
+You can use any number of handles on the slider. The slider will have one handle for every element in the value array.
+
+```html:preview
+<sl-multi-range
+	value="[25,50,75]"
+	style="
+		--track-color-active: var(--sl-color-primary-300);
+		--track-color-inactive: var(--sl-color-neutral-200);
+	"
+></sl-multi-range>
+```
+
+{% raw %}
+
+```jsx:react
+import SlRange from '@shoelace-style/shoelace/dist/react/multi-range';
+
+const App = () => <SlRange value={[25,50,75]} style={{
+	'--track-color-active': 'var(--sl-color-primary-300)',
+	'--track-color-inactive': 'var(--sl-color-neutral-200)'
+}}/>;
+```
+
+{% endraw %}

--- a/src/components/multi-range/multi-range.component.ts
+++ b/src/components/multi-range/multi-range.component.ts
@@ -93,7 +93,9 @@ export default class SlMultiRange extends ShoelaceElement implements ShoelaceFor
   set valueAsArray(value: readonly number[] | null) {
     const oldValue = this.#value;
     this.#value = value || [];
-    this.requestUpdate('value', oldValue.join(','));
+    if (arraysDiffer(oldValue, this.#value)) {
+      this.requestUpdate('value', oldValue.join(','));
+    }
   }
   get valueAsArray() {
     return this.#value;

--- a/src/components/multi-range/multi-range.component.ts
+++ b/src/components/multi-range/multi-range.component.ts
@@ -89,7 +89,7 @@ export default class SlMultiRange extends ShoelaceElement implements ShoelaceFor
     return this.#value.join(',');
   }
 
-  /** Gets of sets the current values of the range as an array of numbers */
+  /** Gets or sets the current values of the range as an array of numbers */
   set valueAsArray(value: readonly number[] | null) {
     const oldValue = this.#value;
     this.#value = value || [];
@@ -97,6 +97,7 @@ export default class SlMultiRange extends ShoelaceElement implements ShoelaceFor
       this.requestUpdate('value', oldValue.join(','));
     }
   }
+
   get valueAsArray() {
     return this.#value;
   }

--- a/src/components/multi-range/multi-range.component.ts
+++ b/src/components/multi-range/multi-range.component.ts
@@ -110,7 +110,7 @@ export default class SlMultiRange extends ShoelaceElement implements ShoelaceFor
    * A function used to format the tooltip's value. The range's value is passed as the first and only argument. The
    * function should return a string to display in the tooltip.
    */
-  @property({ attribute: false }) tooltipFormatter: (value: number) => string = (value: number) => value.toString();
+  @property({ attribute: false }) tooltipFormatter: (value: number) => string;
 
   @query('.base') baseDiv: HTMLDivElement;
   @query('.active-track') activeTrack: HTMLDivElement;
@@ -129,6 +129,11 @@ export default class SlMultiRange extends ShoelaceElement implements ShoelaceFor
 
   get #rtl() {
     return this.#localize.dir() === 'rtl';
+  }
+
+  constructor() {
+    super();
+    this.tooltipFormatter = this.#localize.number.bind(this.#localize);
   }
 
   override render(): unknown {

--- a/src/components/multi-range/multi-range.component.ts
+++ b/src/components/multi-range/multi-range.component.ts
@@ -297,6 +297,8 @@ export default class SlMultiRange extends ShoelaceElement {
         return;
     }
 
+    this.baseDiv.classList.add('keyboard-focus');
+
     if (value !== this.#sliderValues.get(sliderId)) {
       this.#moveHandle(handle, value);
 
@@ -331,14 +333,13 @@ export default class SlMultiRange extends ShoelaceElement {
 
   #onFocus(): void {
     if (this.#hasFocus) return;
-    console.info('sl-focus');
     this.emit('sl-focus');
     this.#hasFocus = true;
   }
 
   #onBlur(event: FocusEvent): void {
+    this.baseDiv?.classList?.remove('keyboard-focus');
     if (event.relatedTarget && this.shadowRoot?.contains(event.relatedTarget as Node)) return;
-    console.info('sl-blur');
     this.emit('sl-blur');
     this.#hasFocus = false;
   }

--- a/src/components/multi-range/multi-range.component.ts
+++ b/src/components/multi-range/multi-range.component.ts
@@ -22,6 +22,11 @@ const arraysDiffer = function (a: readonly number[], b: readonly number[]): bool
   return false;
 };
 
+const csvToArray = function (a: string | null): readonly number[] {
+  if (!a) return [];
+  return a.split(',').map(n => +n);
+};
+
 /**
  * @summary Multi-Ranges allow the user to select multiple values within a given range using a slider with multiple handles.
  * @documentation https://shoelace.style/components/multi-range
@@ -67,7 +72,7 @@ export default class SlMultiRange extends ShoelaceElement {
   @property() tooltip: 'top' | 'bottom' | 'none' = 'top';
 
   /** The current values of the range */
-  @property({ type: Array })
+  @property({ converter: csvToArray })
   set value(value: readonly number[]) {
     this.#value = value || [];
   }

--- a/src/components/multi-range/multi-range.component.ts
+++ b/src/components/multi-range/multi-range.component.ts
@@ -22,11 +22,6 @@ const arraysDiffer = function (a: readonly number[], b: readonly number[]): bool
   return false;
 };
 
-const csvToArray = function (a: string | null): readonly number[] {
-  if (!a) return [];
-  return a.split(',').map(n => +n);
-};
-
 /**
  * @summary Multi-Ranges allow the user to select multiple values within a given range using a slider with multiple handles.
  * @documentation https://shoelace.style/components/multi-range
@@ -71,12 +66,21 @@ export default class SlMultiRange extends ShoelaceElement {
   /** The preferred placement of the range's tooltip. */
   @property() tooltip: 'top' | 'bottom' | 'none' = 'top';
 
-  /** The current values of the range */
-  @property({ converter: csvToArray })
-  set value(value: readonly number[]) {
+  /** The current values of the input (in ascending order) as a string of comma-separated values */
+  @property({ type: String })
+  set value(value: string | null) {
+    this.#value = value ? value.split(',').map(n => +n) : [];
+  }
+
+  get value() {
+    return this.#value.join(',');
+  }
+
+  /** Gets of sets the current values of the range as an array of numbers */
+  set valueAsArray(value: readonly number[] | null) {
     this.#value = value || [];
   }
-  get value() {
+  get valueAsArray() {
     return this.#value;
   }
 
@@ -182,7 +186,7 @@ export default class SlMultiRange extends ShoelaceElement {
       .sort(numericSort);
 
     if (arraysDiffer(this.#value, adjustedValue)) {
-      this.value = adjustedValue;
+      this.#value = adjustedValue;
       if (!changedProperties.has('value')) {
         this.emit('sl-change');
       }
@@ -263,15 +267,15 @@ export default class SlMultiRange extends ShoelaceElement {
     const activeTrack = this.activeTrack;
     if (!activeTrack) return;
 
-    if (this.min === this.max || this.value.length < 2) {
+    if (this.min === this.max || this.#value.length < 2) {
       activeTrack.style.display = 'none';
       activeTrack.style.left = '0';
       activeTrack.style.width = '0';
       return;
     }
 
-    const start = (100 * (this.value[0] - this.min)) / (this.max - this.min);
-    const span = (100 * (this.value[this.value.length - 1] - this.value[0])) / (this.max - this.min);
+    const start = (100 * (this.#value[0] - this.min)) / (this.max - this.min);
+    const span = (100 * (this.#value[this.#value.length - 1] - this.#value[0])) / (this.max - this.min);
 
     activeTrack.style.display = 'inline-block';
     activeTrack.style.left = `${start}%`;

--- a/src/components/multi-range/multi-range.component.ts
+++ b/src/components/multi-range/multi-range.component.ts
@@ -31,7 +31,9 @@ const arraysDiffer = function (a: readonly number[], b: readonly number[]): bool
  * @slot label - The range's label. Alternatively, you can use the `label` attribute.
  * @slot help-text - Text that describes how to use the input. Alternatively, you can use the `help-text` attribute.
  *
+ * @event sl-blur - Emitted when the control loses focus.
  * @event sl-change - Emitted when an alteration to the control's value is committed by the user.
+ * @event sl-focus - Emitted when the control gains focus.
  * @event sl-input - Emitted when the control receives input.
  *
  * @cssproperty --thumb-size - The size of the thumb.
@@ -82,6 +84,7 @@ export default class SlMultiRange extends ShoelaceElement {
   #hasSlotController = new HasSlotController(this, 'help-text', 'label');
   #value: readonly number[] = [0, 100];
   #sliderValues = new Map<number, number>();
+  #hasFocus = false;
   #nextId = 1;
 
   override render(): unknown {
@@ -97,7 +100,7 @@ export default class SlMultiRange extends ShoelaceElement {
           class="handle"
           tabindex="${this.disabled ? -1 : 0}"
           role="slider"
-          aria-labelledby=${ifDefined(hasLabel ? "label" : undefined)}
+          aria-labelledby=${ifDefined(hasLabel ? 'label' : undefined)}
           aria-valuemin="${this.min}"
           aria-valuemax="${this.max}"
           aria-disabled=${ifDefined(this.disabled ? 'true' : undefined)}
@@ -113,12 +116,16 @@ export default class SlMultiRange extends ShoelaceElement {
     });
 
     return html`
-      <div class=${classMap({
+      <div
+        class=${classMap({
           'form-control': true,
           'form-control--medium': true, // range only has one size
           'form-control--has-label': hasLabel,
           'form-control--has-help-text': hasHelpText
-      })}>
+        })}
+        @focusin=${this.#onFocus}
+        @focusout=${this.#onBlur}
+      >
         <label id="label" class="form-control__label" aria-hidden=${hasLabel ? 'false' : 'true'}>
           <slot name="label">${this.label}</slot>
         </label>
@@ -320,5 +327,19 @@ export default class SlMultiRange extends ShoelaceElement {
     handle.setAttribute('aria-valuetext', this.tooltipFormatter(value));
     const pos = (value - this.min) / (this.max - this.min);
     handle.style.left = `calc( ${100 * pos}% - var(--thumb-size) * ${pos} )`;
+  }
+
+  #onFocus(): void {
+    if (this.#hasFocus) return;
+    console.info('sl-focus');
+    this.emit('sl-focus');
+    this.#hasFocus = true;
+  }
+
+  #onBlur(event: FocusEvent): void {
+    if (event.relatedTarget && this.shadowRoot?.contains(event.relatedTarget as Node)) return;
+    console.info('sl-blur');
+    this.emit('sl-blur');
+    this.#hasFocus = false;
   }
 }

--- a/src/components/multi-range/multi-range.component.ts
+++ b/src/components/multi-range/multi-range.component.ts
@@ -91,7 +91,9 @@ export default class SlMultiRange extends ShoelaceElement implements ShoelaceFor
 
   /** Gets of sets the current values of the range as an array of numbers */
   set valueAsArray(value: readonly number[] | null) {
+    const oldValue = this.#value;
     this.#value = value || [];
+    this.requestUpdate('value', oldValue.join(','));
   }
   get valueAsArray() {
     return this.#value;

--- a/src/components/multi-range/multi-range.component.ts
+++ b/src/components/multi-range/multi-range.component.ts
@@ -1,0 +1,299 @@
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { property, query, queryAll } from 'lit/decorators.js';
+import ShoelaceElement from '../../internal/shoelace-element.js';
+import styles from './multi-range.styles.js';
+import type { CSSResultGroup, PropertyValues } from 'lit';
+
+const numericSort = function (a: number, b: number): number {
+  return a - b;
+};
+
+const arraysDiffer = function (a: readonly number[], b: readonly number[]): boolean {
+  a ||= [];
+  b ||= [];
+  if (a.length !== b.length) return true;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return true;
+  }
+  return false;
+};
+
+/**
+ * @summary Multi-Ranges allow the user to select multiple values within a given range using a slider with multiple handles.
+ * @documentation https://shoelace.style/components/multi-range
+ * @status experimental
+ * @since next
+ *
+ * @event sl-change - Emitted when an alteration to the control's value is committed by the user.
+ * @event sl-input - Emitted when the control receives input.
+ *
+ * @cssproperty --thumb-size - The size of the thumb.
+ * @cssproperty --track-color-active - The color of the portion of the track that represents the current value.
+ * @cssproperty --track-color-inactive - The of the portion of the track that represents the remaining value.
+ * @cssproperty --track-height - The height of the track.
+ */
+export default class SlMultiRange extends ShoelaceElement {
+  static styles: CSSResultGroup = [styles];
+
+  /** The range's label. */
+  @property() label = '';
+
+  /** Disables the range. */
+  @property({ type: Boolean, reflect: true }) disabled = false;
+
+  /** The minimum acceptable value of the range. */
+  @property({ type: Number }) min = 0;
+
+  /** The maximum acceptable value of the range. */
+  @property({ type: Number }) max = 100;
+
+  /** The interval at which the range will increase and decrease. */
+  @property({ type: Number }) step = 1;
+
+  /** The current values of the range */
+  @property({ type: Array })
+  set value(value: readonly number[]) {
+    this.#value = value || [];
+  }
+  get value() {
+    return this.#value;
+  }
+
+  /**
+   * A function used to format the tooltip's value. The range's value is passed as the first and only argument. The
+   * function should return a string to display in the tooltip.
+   */
+  @property({ attribute: false }) tooltipFormatter: (value: number) => string = (value: number) => value.toString();
+
+  @query('.base') baseDiv: HTMLDivElement;
+  @query('.active-track') activeTrack: HTMLDivElement;
+  @queryAll('.handle') handles: NodeListOf<HTMLDivElement>;
+
+  #value: readonly number[] = [0, 100];
+  #sliderValues = new Map<number, number>();
+  #nextId = 1;
+
+  override render(): unknown {
+    this.#sliderValues.clear();
+    const handles = this.#value.map(value => {
+      const sliderId = this.#nextId++;
+      this.#sliderValues.set(sliderId, value);
+      return html`
+        <div
+          class="handle"
+          tabindex="${this.disabled ? -1 : 0}"
+          role="slider"
+          aria-label="${this.label}"
+          aria-valuemin="${this.min}"
+          aria-valuemax="${this.max}"
+          aria-disabled=${ifDefined(this.disabled ? 'true' : undefined)}
+          aria-valuenow="${value}"
+          data-slider-id="${sliderId}"
+          @pointerdown=${this.#onClickHandle}
+          @pointermove=${this.#onDragHandle}
+          @pointerup=${this.#onReleaseHandle}
+          @pointercancel=${this.#onReleaseHandle}
+          @keydown=${this.#onKeyPress}
+        ></div>
+      `;
+    });
+
+    return html`
+      <label ?hidden=${!this.label}>${this.label}</label>
+      <div class="base">
+        <div class="track"></div>
+        <div class="active-track"></div>
+        ${handles}
+      </div>
+    `;
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues): void {
+    super.willUpdate(changedProperties);
+
+    if (this.min > this.max) {
+      [this.min, this.max] = [this.max, this.min];
+    }
+
+    if (this.step > this.max - this.min) {
+      this.step = this.max - this.min;
+    }
+
+    if (this.step <= 0) {
+      this.step = 1;
+    }
+
+    const adjustedValue = this.#value
+      .map(value => {
+        if (value <= this.min) return this.min;
+        if (value >= this.max) return this.max;
+        value = this.min + this.step * Math.round((value - this.min) / this.step);
+        if (value > this.max) return this.max;
+        return value;
+      })
+      .sort(numericSort);
+
+    if (arraysDiffer(this.#value, adjustedValue)) {
+      this.value = adjustedValue;
+      if (!changedProperties.has('value')) {
+        this.emit('sl-change');
+      }
+    }
+  }
+
+  protected override updated(changedProperties: PropertyValues): void {
+    super.updated(changedProperties);
+    for (const handle of this.handles) {
+      const sliderId = +handle.dataset.sliderId!;
+      if (!this.#sliderValues.has(sliderId)) continue;
+      this.#moveHandle(handle, this.#sliderValues.get(sliderId)!);
+    }
+    this.#updateActiveTrack();
+  }
+
+  override focus(options?: FocusOptions): void {
+    const firstHandle = this.handles.item(0);
+    if (firstHandle) {
+      firstHandle.focus(options);
+    } else {
+      super.focus(options);
+    }
+  }
+
+  #onClickHandle(event: PointerEvent): void {
+    const handle = event.target as HTMLDivElement;
+
+    if (handle.dataset.pointerId) {
+      handle.releasePointerCapture(+handle.dataset.pointerId);
+    }
+
+    if (this.disabled) return;
+
+    handle.dataset.pointerId = event.pointerId.toString();
+    handle.setPointerCapture(event.pointerId);
+    handle.classList.add('grabbed');
+  }
+
+  #onDragHandle(event: PointerEvent): void {
+    if (this.disabled) return;
+
+    const handle = event.target as HTMLDivElement;
+    const sliderId = +handle.dataset.sliderId!;
+    if (!this.#sliderValues.has(sliderId)) return;
+
+    const pointerId = handle.dataset.pointerId ? +handle.dataset.pointerId : null;
+    if (pointerId !== event.pointerId) return;
+
+    const pos = this.#getNormalizedValueFromClientX(handle, event.clientX);
+    const unit = this.step / (this.max - this.min);
+    const value = this.min + this.step * Math.round(pos / unit);
+    this.#sliderValues.set(sliderId, value);
+    this.#moveHandle(handle, value);
+
+    const prevValue = this.#value;
+    this.#value = Array.from(this.#sliderValues.values()).sort(numericSort);
+    this.#updateActiveTrack();
+
+    if (arraysDiffer(prevValue, this.#value)) {
+      this.emit('sl-input');
+    }
+  }
+
+  #getNormalizedValueFromClientX(handle: HTMLDivElement, x: number): number {
+    const bounds = this.baseDiv.getBoundingClientRect();
+    const size = bounds.width - handle.clientWidth;
+    if (size <= 0) return 0;
+    x -= bounds.left + handle.clientWidth / 2;
+    if (x <= 0) return 0;
+    if (x >= size) return 1;
+    return x / size;
+  }
+
+  #updateActiveTrack(): void {
+    const activeTrack = this.activeTrack;
+    if (!activeTrack) return;
+
+    if (this.min === this.max || this.value.length < 2) {
+      activeTrack.style.display = 'none';
+      activeTrack.style.left = '0';
+      activeTrack.style.width = '0';
+      return;
+    }
+
+    const start = (100 * (this.value[0] - this.min)) / (this.max - this.min);
+    const span = (100 * (this.value[this.value.length - 1] - this.value[0])) / (this.max - this.min);
+
+    activeTrack.style.display = 'inline-block';
+    activeTrack.style.left = `${start}%`;
+    activeTrack.style.width = `${span}%`;
+  }
+
+  #onKeyPress(event: KeyboardEvent): void {
+    const handle = event.target as HTMLDivElement;
+    const sliderId = +handle.dataset.sliderId!;
+
+    let value = this.#sliderValues.get(sliderId);
+    if (value === undefined) return;
+
+    switch (event.key) {
+      case 'ArrowUp':
+      case 'ArrowRight':
+      case 'Up':
+      case 'Right':
+        value = Math.min(value + this.step, this.max);
+        break;
+      case 'ArrowDown':
+      case 'ArrowLeft':
+      case 'Down':
+      case 'Left':
+        value = Math.max(value - this.step, this.min);
+        break;
+      case 'PageUp':
+        value = Math.min(value + 10 * this.step, this.max);
+        break;
+      case 'PageDown':
+        value = Math.max(value - 10 * this.step, this.min);
+        break;
+      case 'Home':
+        value = this.min;
+        break;
+      case 'End':
+        value = this.max;
+        break;
+      default:
+        return;
+    }
+
+    if (value !== this.#sliderValues.get(sliderId)) {
+      this.#moveHandle(handle, value);
+
+      this.#sliderValues.set(sliderId, value);
+      this.#value = Array.from(this.#sliderValues.values()).sort(numericSort);
+      this.#updateActiveTrack();
+
+      this.emit('sl-input');
+      this.emit('sl-change');
+    }
+
+    event.stopPropagation();
+    event.preventDefault();
+  }
+
+  #onReleaseHandle(event: PointerEvent) {
+    const handle = event.target as HTMLDivElement;
+    if (!handle.dataset.pointerId || event.pointerId !== +handle.dataset.pointerId) return;
+
+    handle.classList.remove('grabbed');
+    handle.releasePointerCapture(event.pointerId);
+    delete handle.dataset.pointerId;
+    this.emit('sl-change');
+  }
+
+  #moveHandle(handle: HTMLDivElement, value: number): void {
+    handle.setAttribute('aria-valuenow', value.toString());
+    handle.setAttribute('aria-valuetext', this.tooltipFormatter(value));
+    const pos = (value - this.min) / (this.max - this.min);
+    handle.style.left = `calc( ${100 * pos}% - var(--thumb-size) * ${pos} )`;
+  }
+}

--- a/src/components/multi-range/multi-range.component.ts
+++ b/src/components/multi-range/multi-range.component.ts
@@ -290,7 +290,7 @@ export default class SlMultiRange extends ShoelaceElement implements ShoelaceFor
       tooLong: false,
       tooShort: false,
       typeMismatch: false,
-      valid: !!this.#validationError,
+      valid: !this.#validationError,
       valueMissing: false
     };
   }

--- a/src/components/multi-range/multi-range.component.ts
+++ b/src/components/multi-range/multi-range.component.ts
@@ -40,6 +40,12 @@ const arraysDiffer = function (a: readonly number[], b: readonly number[]): bool
  * @event sl-focus - Emitted when the control gains focus.
  * @event sl-input - Emitted when the control receives input.
  *
+ * @csspart form-control - The form control that wraps the label, input, and help text.
+ * @csspart form-control-label - The label's wrapper.
+ * @csspart form-control-help-text - The help text's wrapper.
+ * @csspart base - The component's base wrapper.
+ * @csspart tooltip - The range's tooltip.
+ *
  * @cssproperty --thumb-size - The size of the thumb.
  * @cssproperty --tooltip-offset - The vertical distance the tooltip is offset from the track.
  * @cssproperty --track-color-active - The color of the portion of the track that represents the current value.
@@ -118,7 +124,8 @@ export default class SlMultiRange extends ShoelaceElement implements ShoelaceFor
     const hasLabel = !!(this.label || this.#hasSlotController.test('label'));
     const hasHelpText = !!(this.helpText || this.#hasSlotController.test('help-text'));
 
-    const tooltip = this.tooltip !== 'none' ? html`<div class="tooltip" aria-hidden="true"></div>` : nothing;
+    const tooltip =
+      this.tooltip !== 'none' ? html`<div class="tooltip" part="tooltip" aria-hidden="true"></div>` : nothing;
 
     this.#sliderValues.clear();
     const handles = this.#value.map(value => {
@@ -147,6 +154,7 @@ export default class SlMultiRange extends ShoelaceElement implements ShoelaceFor
 
     return html`
       <div
+        part="form-control"
         class=${classMap({
           'form-control': true,
           'form-control--medium': true, // range only has one size
@@ -157,15 +165,24 @@ export default class SlMultiRange extends ShoelaceElement implements ShoelaceFor
         })}
         @focusout=${this.#onBlur}
       >
-        <label id="label" class="form-control__label" aria-hidden=${hasLabel ? 'false' : 'true'}>
+        <label
+          id="label"
+          part="form-control-label"
+          class="form-control__label"
+          aria-hidden=${hasLabel ? 'false' : 'true'}
+        >
           <slot name="label">${this.label}</slot>
         </label>
-        <div class="base">
+        <div class="base" part="base">
           <div class="track"></div>
           <div class="active-track"></div>
           ${handles} ${tooltip}
         </div>
-        <div class="form-control__help-text" aria-hidden=${hasHelpText ? 'false' : 'true'}>
+        <div
+          part="form-control-help-text"
+          class="form-control__help-text"
+          aria-hidden=${hasHelpText ? 'false' : 'true'}
+        >
           <slot name="help-text">${this.helpText}</slot>
         </div>
       </div>

--- a/src/components/multi-range/multi-range.styles.ts
+++ b/src/components/multi-range/multi-range.styles.ts
@@ -63,7 +63,7 @@ export default css`
     cursor: grabbing;
   }
 
-  .handle:focus-visible {
+  .handle:focus-visible, .keyboard-focus .handle:focus {
     outline: var(--sl-focus-ring);
     outline-offset: var(--sl-focus-ring-offset);
   }

--- a/src/components/multi-range/multi-range.styles.ts
+++ b/src/components/multi-range/multi-range.styles.ts
@@ -3,7 +3,7 @@ import { css } from 'lit';
 export default css`
   :host {
     --thumb-size: 20px;
-    --track-color-active: var(--sl-color-neutral-200);
+    --track-color-active: var(--sl-color-primary-300);
     --track-color-inactive: var(--sl-color-neutral-200);
     --track-height: 6px;
   }

--- a/src/components/multi-range/multi-range.styles.ts
+++ b/src/components/multi-range/multi-range.styles.ts
@@ -14,6 +14,7 @@ export default css`
     flex-direction: column;
     align-items: stretch;
     box-sizing: border-box;
+    writing-mode: horizontal-tb;
   }
 
   .base {

--- a/src/components/multi-range/multi-range.styles.ts
+++ b/src/components/multi-range/multi-range.styles.ts
@@ -63,7 +63,8 @@ export default css`
     cursor: grabbing;
   }
 
-  .handle:focus-visible, .keyboard-focus .handle:focus {
+  .handle:focus-visible,
+  .keyboard-focus .handle:focus {
     outline: var(--sl-focus-ring);
     outline-offset: var(--sl-focus-ring-offset);
   }

--- a/src/components/multi-range/multi-range.styles.ts
+++ b/src/components/multi-range/multi-range.styles.ts
@@ -6,21 +6,13 @@ export default css`
     --track-color-active: var(--sl-color-neutral-200);
     --track-color-inactive: var(--sl-color-neutral-200);
     --track-height: 6px;
+  }
 
+  .form-control {
     display: flex;
     flex-direction: column;
     align-items: stretch;
     box-sizing: border-box;
-  }
-
-  label {
-    display: inline-block;
-    color: var(--sl-input-label-color);
-    margin-bottom: var(--sl-spacing-3x-small);
-  }
-
-  label[hidden] {
-    display: none;
   }
 
   .base {

--- a/src/components/multi-range/multi-range.styles.ts
+++ b/src/components/multi-range/multi-range.styles.ts
@@ -3,6 +3,7 @@ import { css } from 'lit';
 export default css`
   :host {
     --thumb-size: 20px;
+    --tooltip-offset: 10px;
     --track-color-active: var(--sl-color-primary-300);
     --track-color-inactive: var(--sl-color-neutral-200);
     --track-height: 6px;
@@ -72,5 +73,59 @@ export default css`
   :host([disabled]) .handle,
   :host([disabled]) .handle.grabbed {
     cursor: not-allowed;
+  }
+
+  .tooltip {
+    position: absolute;
+    z-index: var(--sl-z-index-tooltip);
+    left: 0;
+    border-radius: var(--sl-tooltip-border-radius);
+    background-color: var(--sl-tooltip-background-color);
+    font-family: var(--sl-tooltip-font-family);
+    font-size: var(--sl-tooltip-font-size);
+    font-weight: var(--sl-tooltip-font-weight);
+    line-height: var(--sl-tooltip-line-height);
+    color: var(--sl-tooltip-color);
+    opacity: 0;
+    padding: var(--sl-tooltip-padding);
+    transition: var(--sl-transition-fast) opacity;
+    pointer-events: none;
+  }
+
+  .tooltip:after {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    left: 50%;
+    translate: calc(-1 * var(--sl-tooltip-arrow-size));
+  }
+
+  .tooltip-visible .tooltip {
+    opacity: 1;
+  }
+
+  /* Tooltip on top */
+  .tooltip-top .tooltip {
+    top: calc(-1 * var(--thumb-size) - var(--tooltip-offset));
+  }
+
+  .tooltip-top .tooltip:after {
+    border-top: var(--sl-tooltip-arrow-size) solid var(--sl-tooltip-background-color);
+    border-left: var(--sl-tooltip-arrow-size) solid transparent;
+    border-right: var(--sl-tooltip-arrow-size) solid transparent;
+    top: 100%;
+  }
+
+  /* Tooltip on bottom */
+  .tooltip-bottom .tooltip {
+    bottom: calc(-1 * var(--thumb-size) - var(--tooltip-offset));
+  }
+
+  .tooltip-bottom .tooltip:after {
+    border-bottom: var(--sl-tooltip-arrow-size) solid var(--sl-tooltip-background-color);
+    border-left: var(--sl-tooltip-arrow-size) solid transparent;
+    border-right: var(--sl-tooltip-arrow-size) solid transparent;
+    bottom: 100%;
   }
 `;

--- a/src/components/multi-range/multi-range.styles.ts
+++ b/src/components/multi-range/multi-range.styles.ts
@@ -1,0 +1,83 @@
+import { css } from 'lit';
+
+export default css`
+  :host {
+    --thumb-size: 20px;
+    --track-color-active: var(--sl-color-neutral-200);
+    --track-color-inactive: var(--sl-color-neutral-200);
+    --track-height: 6px;
+
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    box-sizing: border-box;
+  }
+
+  label {
+    display: inline-block;
+    color: var(--sl-input-label-color);
+    margin-bottom: var(--sl-spacing-3x-small);
+  }
+
+  label[hidden] {
+    display: none;
+  }
+
+  .base {
+    display: block;
+    position: relative;
+    height: var(--thumb-size);
+  }
+
+  :host([disabled]) .base {
+    opacity: 0.5;
+  }
+
+  .track {
+    display: inline-block;
+    height: var(--track-height);
+    width: calc(100% + 6px - var(--thumb-size));
+    border-radius: 3px;
+    margin: calc((var(--thumb-size) - var(--track-height)) / 2) calc(var(--thumb-size) / 2 - 3px);
+    background-color: var(--track-color-inactive);
+  }
+
+  .active-track {
+    position: absolute;
+    top: calc((var(--thumb-size) - var(--track-height)) / 2);
+    height: var(--track-height);
+    background-color: var(--track-color-active);
+    z-index: 2;
+  }
+
+  .handle {
+    display: block;
+    position: absolute;
+    top: 0;
+    width: var(--thumb-size);
+    height: var(--thumb-size);
+    border-radius: 50%;
+    background-color: var(--sl-color-primary-600);
+    z-index: 3;
+    cursor: pointer;
+  }
+
+  .handle:hover,
+  .handle.grabbed {
+    background-color: var(--sl-color-primary-500);
+  }
+
+  .handle.grabbed {
+    cursor: grabbing;
+  }
+
+  .handle:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  :host([disabled]) .handle,
+  :host([disabled]) .handle.grabbed {
+    cursor: not-allowed;
+  }
+`;

--- a/src/components/multi-range/multi-range.ts
+++ b/src/components/multi-range/multi-range.ts
@@ -1,0 +1,12 @@
+import SlMultiRange from './multi-range.component.js';
+
+export * from './multi-range.component.js';
+export default SlMultiRange;
+
+SlMultiRange.define('sl-multi-range');
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sl-multi-range': SlMultiRange;
+  }
+}

--- a/src/shoelace.ts
+++ b/src/shoelace.ts
@@ -30,6 +30,7 @@ export { default as SlInput } from './components/input/input.js';
 export { default as SlMenu } from './components/menu/menu.js';
 export { default as SlMenuItem } from './components/menu-item/menu-item.js';
 export { default as SlMenuLabel } from './components/menu-label/menu-label.js';
+export { default as SlMultiRange } from './components/multi-range/multi-range.js';
 export { default as SlMutationObserver } from './components/mutation-observer/mutation-observer.js';
 export { default as SlOption } from './components/option/option.js';
 export { default as SlPopup } from './components/popup/popup.js';


### PR DESCRIPTION
Implements https://github.com/shoelace-style/shoelace/issues/616
Currently, Shoelace implements an `sl-range` component for a simple slider with one value.

This pull request is a prototype for a new similar component that differs in that it supports more than one value/handle. The most common use case is using two values to select a range, but the component supports an arbitrary number of handles.

There aren't any unit tests, but everything else is now implemented

![image](https://github.com/shoelace-style/shoelace/assets/19809243/f15b163a-3cee-476a-9e2a-11fededeac8a)
