### PR TITLE
Fixed Firefox select-test

### DIFF
--- a/src/components/select/select.test.ts
+++ b/src/components/select/select.test.ts
@@ -462,7 +462,7 @@ describe('<sl-select>', () => {
       await select.updateComplete;
       expect(select.value).to.equal('option-3');
 
-      setTimeout(() => clickOnElement(resetButton));
+      setTimeout(() => resetButton.click());
       await oneEvent(form, 'reset');
       await select.updateComplete;
       expect(select.value).to.equal('option-1');

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -23,9 +23,7 @@ export default {
   ],
   browsers: [
     playwrightLauncher({ product: 'chromium' }),
-    // Firefox started failing randomly so we're temporarily disabling it here. This could be a rogue test, not really
-    // sure what's happening.
-    // playwrightLauncher({ product: 'firefox' }),
+    playwrightLauncher({ product: 'firefox' }),
     playwrightLauncher({ product: 'webkit' })
   ],
   testRunnerHtml: testFramework => `

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -23,7 +23,9 @@ export default {
   ],
   browsers: [
     playwrightLauncher({ product: 'chromium' }),
-    playwrightLauncher({ product: 'firefox' }),
+    // Firefox started failing randomly so we're temporarily disabling it here. This could be a rogue test, not really
+    // sure what's happening.
+    // playwrightLauncher({ product: 'firefox' }),
     playwrightLauncher({ product: 'webkit' })
   ],
   testRunnerHtml: testFramework => `


### PR DESCRIPTION
Fixes the following issue: #1915 

It appears that in the reset-example the select overlays the button, and therefor the button cannot be pressed with the clickOnElement function (which uses screen coordinates). I verified this behavior using a 200px top-margin on the button, which also solves this behavior. Nevertheless, just calling click() appears a bit cleaner to me.


I further investigated the other failing test (color-picker): "should emit sl-focus when rendered inline and focused" fails regularly.
- the number of focus events is 2 or 3 instead of 1.
- it is not really related to the color-picker. In the test I replaced it with the sl-checkbox. same result.
- I narrowed it down to the carousel test, which is run before. if this test is skipped the false positives of the color-picker vanish.
- the carousel / autoplay does smth. with the focus and blur events. there might be a connection.