### PR TITLE
dropdown: prevent capture of space key when trigger slot element is sl-input

### DIFF
--- a/src/components/dropdown/dropdown.component.ts
+++ b/src/components/dropdown/dropdown.component.ts
@@ -218,7 +218,12 @@ export default class SlDropdown extends ShoelaceElement {
   async handleTriggerKeyDown(event: KeyboardEvent) {
     // When spacebar/enter is pressed, show the panel but don't focus on the menu. This let's the user press the same
     // key again to hide the menu in case they don't want to make a selection.
-    if ([' ', 'Enter'].includes(event.key)) {
+    let toggleShowKeys = [' ', 'Enter'];
+    if (this.trigger?.assignedElements().length > 0 && this.trigger?.assignedElements()[0].tagName === 'SL-INPUT') {
+      // If the trigger is a sl-input, then don't hijack the space character
+      toggleShowKeys = ['Enter'];
+    }
+    if (toggleShowKeys.includes(event.key)) {
       event.preventDefault();
       this.handleTriggerClick();
       return;


### PR DESCRIPTION
when an `sl-input` is used as a trigger slot for the dropdown element, then we don't want to capture the `space` key, only the `enter` key. capturing the `space` key prevents the user from typing a space in the sl-input.

Using the combination of `sl-dropdown` with a `sl-input` trigger slot is very useful when creating an autocomplete component.