### PR TITLE
`<sl-split-panel>` breaks when hidden

### DIFF
--- a/src/components/split-panel/split-panel.test.ts
+++ b/src/components/split-panel/split-panel.test.ts
@@ -290,4 +290,19 @@ describe('<sl-split-panel>', () => {
       expect(positionInPixelsAfterDrag).to.be.equal(positionInPixels - 40);
     });
   });
+
+  it('correctly handles being hidden', async () => {
+    const splitPanel = await fixture<SlSplitPanel>(
+      html`<sl-split-panel style="display: none;" position-in-pixels="100">
+        <div slot="start">Start</div>
+        <div slot="end">End</div>
+      </sl-split-panel>`
+    );
+
+    splitPanel.style.display = 'block';
+    await new Promise(r => setTimeout(r, 1));
+
+    const positionInPixelsAfterShow = splitPanel.positionInPixels;
+    expect(positionInPixelsAfterShow).to.be.equal(100);
+  });
 });


### PR DESCRIPTION
I ran into the following issue when I nested an `<sl-split-panel>` inside an `<sl-tab-panel>`:

When an `<sl-split-panel>` starts off in a hidden state, so that its bounding client rectangle is 0, the position attribute goes into a glitched `NaN` state, which persists even after it becomes visible.

This pull request adds a failing test case for this to demonstrate the behavior. (There may be more variations that need to be tested, like what happens when an `<sl-split-panel>` becomes subsequently hidden, or when it is instantiated with `position` vs. `position-in-pixels`.)

Some cursory debugging with `console.log` suggests that when `handlePositionInPixelsChange()` is called on component initialization, it [calls](https://github.com/shoelace-style/shoelace/blob/ae66483671ab65ae381c314b78bb840335e5da85/src/components/split-panel/split-panel.component.ts#L207) `this.pixelsToPercentage`, which in turns [divides by zero](https://github.com/shoelace-style/shoelace/blob/ae66483671ab65ae381c314b78bb840335e5da85/src/components/split-panel/split-panel.component.ts#L101) as `this.size` is 0. There are presumably more code paths where the zero size can break something, but I haven't checked further.