### PR TITLE
Update docs for customizing button widths

### DIFF
--- a/docs/pages/components/button.md
+++ b/docs/pages/components/button.md
@@ -236,7 +236,7 @@ When a `target` is set, the link will receive `rel="noreferrer noopener"` for [s
 
 ### Setting a Custom Width
 
-As expected, buttons can be given a custom width by setting the `width` attribute. This is useful for making buttons span the full width of their container on smaller screens.
+As expected, buttons can be given a custom width by passing inline styles to the component (or using a class). This is useful for making buttons span the full width of their container on smaller screens.
 
 ```html:preview
 <sl-button variant="default" size="small" style="width: 100%; margin-bottom: 1rem;">Small</sl-button>


### PR DESCRIPTION
Currently, the docs state that you can set use the `width` attribute to customize the width of buttons but as far as I can tell no such attribute exists. I've updated the docs to direct people to set a custom width via CSS through inline styles or a custom class.