### PR TITLE
fix: invalid css on button style

### DIFF
--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -590,7 +590,7 @@ export default css`
 
   /* Focus and checked are always on top */
   :host([data-sl-button-group__button--focus]),
-  :host([data-sl-button-group__button[checked]]) {
+  :host([data-sl-button-group__button][checked]) {
     z-index: 2;
   }
 `;


### PR DESCRIPTION
This PR fixes the issue https://github.com/shoelace-style/shoelace/issues/1974 and fixes the invalid css, so the focus button style in button-groups is correct again