### PR TITLE
prevent harmless error in radio-group when non-radio-button is clicked

### DIFF
--- a/src/components/radio-group/radio-group.component.ts
+++ b/src/components/radio-group/radio-group.component.ts
@@ -129,11 +129,11 @@ export default class SlRadioGroup extends ShoelaceElement implements ShoelaceFor
   }
 
   private handleRadioClick(event: MouseEvent) {
-    const target = (event.target as HTMLElement).closest<SlRadio | SlRadioButton>('sl-radio, sl-radio-button')!;
+    const target = event.target.closest<SlRadio | SlRadioButton>('sl-radio, sl-radio-button')!;
     const radios = this.getAllRadios();
     const oldValue = this.value;
 
-    if (target.disabled) {
+    if (!target || target.disabled) {
       return;
     }
 


### PR DESCRIPTION
It is sometimes useful to stick non-radio(-button) elements in radio-group to achieve certain effects. In case the clicked element is not a radio-button or radio, skip the logic (instead of throwing an error reading `disabled` of `null`).

Example:

```html
<sl-radio-group>
  <div class="radio-wrapper">
    <sl-radio-button>...</sl-radio-button>
    <sl-copy-button></sl-copy-button>
  </div>
  <div class="radio-wrapper">
    <sl-radio-button>...</sl-radio-button>
    <sl-copy-button></sl-copy-button>
  </div>
  ...
</sl-radio-group>
```

Actual example screenshot (copy-button is outside of the radio-button so that behaviors of hover effects, tooltips, etc, of the radio-button are not mixed with those of the copy-button (for example we don't want a tooltip from inside the radio-button to also trigger while hovering on the copy-button)):

<img width="297" alt="Screenshot 2024-04-16 at 11 03 03 PM" src="https://github.com/shoelace-style/shoelace/assets/297678/edec6452-4037-45d4-a9a1-c83342285b3d">

(its a vertical layout, each rectangle is a radio-button, each one shows a copy-button on hover)


Even with the error, this approach works really well, the sl-radio-group is written in a way that the wrappers don't mess it up. The error is harmless too, everything still works with the error because no logic after the error is necessary (equivalent to returning early and doing nothing).