### PR TITLE
Add support for sl-dropdown in the default slot of sl-breadcrumb-item

### DIFF
--- a/docs/pages/components/breadcrumb.md
+++ b/docs/pages/components/breadcrumb.md
@@ -256,3 +256,62 @@ const App = () => (
   </SlBreadcrumb>
 );
 ```
+
+### With Dropdowns in default slot
+
+Dropdown menus can be placed in the default slot to provide additional options.
+
+```html:preview
+<sl-breadcrumb>
+  <sl-breadcrumb-item>Homepage</sl-breadcrumb-item>
+  <sl-breadcrumb-item>
+    <sl-dropdown>
+      <sl-button slot="trigger" size="small" circle>
+        <sl-icon label="More options" name="three-dots"></sl-icon>
+      </sl-button>
+      <sl-menu>
+        <sl-menu-item type="checkbox" checked>Web Design</sl-menu-item>
+        <sl-menu-item type="checkbox">Web Development</sl-menu-item>
+        <sl-menu-item type="checkbox">Marketing</sl-menu-item>
+      </sl-menu>
+    </sl-dropdown>
+  </sl-breadcrumb-item>
+  <sl-breadcrumb-item>Our Services</sl-breadcrumb-item>
+  <sl-breadcrumb-item>Digital Media</sl-breadcrumb-item>
+</sl-breadcrumb>
+```
+
+```jsx:react
+import {
+  SlBreadcrumb,
+  SlBreadcrumbItem,
+  SlButton,
+  SlDropdown,
+  SlIcon,
+  SlMenu,
+  SlMenuItem
+} from '@shoelace-style/shoelace/dist/react';
+
+const App = () => (
+  <SlBreadcrumb>
+    <SlBreadcrumbItem>Homepage</SlBreadcrumbItem>
+    <SlBreadcrumbItem>Our Services</SlBreadcrumbItem>
+    <SlBreadcrumbItem>Digital Media</SlBreadcrumbItem>
+    <SlBreadcrumbItem>
+      Web Design
+      <SlDropdown slot="suffix">
+        <SlButton slot="trigger" size="small" circle>
+          <SlIcon label="More options" name="three-dots"></SlIcon>
+        </SlButton>
+        <SlMenu>
+          <SlMenuItem type="checkbox" checked>
+            Web Design
+          </SlMenuItem>
+          <SlMenuItem type="checkbox">Web Development</SlMenuItem>
+          <SlMenuItem type="checkbox">Marketing</SlMenuItem>
+        </SlMenu>
+      </SlDropdown>
+    </SlBreadcrumbItem>
+  </SlBreadcrumb>
+);
+```

--- a/docs/pages/components/breadcrumb.md
+++ b/docs/pages/components/breadcrumb.md
@@ -295,10 +295,7 @@ import {
 const App = () => (
   <SlBreadcrumb>
     <SlBreadcrumbItem>Homepage</SlBreadcrumbItem>
-    <SlBreadcrumbItem>Our Services</SlBreadcrumbItem>
-    <SlBreadcrumbItem>Digital Media</SlBreadcrumbItem>
     <SlBreadcrumbItem>
-      Web Design
       <SlDropdown slot="suffix">
         <SlButton slot="trigger" size="small" circle>
           <SlIcon label="More options" name="three-dots"></SlIcon>
@@ -312,6 +309,8 @@ const App = () => (
         </SlMenu>
       </SlDropdown>
     </SlBreadcrumbItem>
+    <SlBreadcrumbItem>Our Services</SlBreadcrumbItem>
+    <SlBreadcrumbItem>Digital Media</SlBreadcrumbItem>
   </SlBreadcrumb>
 );
 ```

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -14,6 +14,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 
 ## Next
 
+- Added support for using `<sl-dropdown>` in `<sl-breadcrumb-item>` default slot [#2015]
 - Fixed a bug in `<sl-radio-group>` where if a click did not contain a `<sl-radio>` it would show a console error. [#2009]
 - Fixed a bug in `<sl-split-panel>` that caused it not to recalculate it's position when going from being `display: none;` to its original display value. [#1942]
 - Fixed a bug in `<dialog>` where when it showed it would cause a layout shift. [#1967]

--- a/src/components/breadcrumb-item/breadcrumb-item.component.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.component.ts
@@ -34,7 +34,7 @@ export default class SlBreadcrumbItem extends ShoelaceElement {
 
   @query('slot:not([name])') defaultSlot: HTMLSlotElement;
 
-  @state() private renderType: 'button' | 'link' | 'drop-down' = 'button';
+  @state() private renderType: 'button' | 'link' | 'dropdown' = 'button';
 
   /**
    * Optional URL to direct the user to when the breadcrumb item is activated. When set, a link will be rendered

--- a/src/components/breadcrumb-item/breadcrumb-item.component.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.component.ts
@@ -3,6 +3,7 @@ import { HasSlotController } from '../../internal/slot.js';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { property, query, state } from 'lit/decorators.js';
+import { watch } from '../../internal/watch.js';
 import componentStyles from '../../styles/component.styles.js';
 import ShoelaceElement from '../../internal/shoelace-element.js';
 import styles from './breadcrumb-item.styles.js';
@@ -47,12 +48,21 @@ export default class SlBreadcrumbItem extends ShoelaceElement {
   /** The `rel` attribute to use on the link. Only used when `href` is set. */
   @property() rel = 'noreferrer noopener';
 
-  handleSlotChange() {
+  private setRenderType() {
     const hasDropdown =
       this.defaultSlot.assignedElements({ flatten: true }).filter(i => i.tagName.toLowerCase() === 'sl-dropdown')
         .length > 0;
 
     this.renderType = this.href ? 'link' : hasDropdown ? 'drop-down' : 'button';
+  }
+
+  @watch('href', { waitUntilFirstUpdate: true })
+  hrefChanged() {
+    this.setRenderType();
+  }
+
+  handleSlotChange() {
+    this.setRenderType();
   }
 
   render() {

--- a/src/components/breadcrumb-item/breadcrumb-item.component.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.component.ts
@@ -2,7 +2,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { HasSlotController } from '../../internal/slot.js';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { property } from 'lit/decorators.js';
+import { property, query, state } from 'lit/decorators.js';
 import componentStyles from '../../styles/component.styles.js';
 import ShoelaceElement from '../../internal/shoelace-element.js';
 import styles from './breadcrumb-item.styles.js';
@@ -31,6 +31,10 @@ export default class SlBreadcrumbItem extends ShoelaceElement {
 
   private readonly hasSlotController = new HasSlotController(this, 'prefix', 'suffix');
 
+  @query('slot:not([name])') defaultSlot: HTMLSlotElement;
+
+  @state() private renderType: 'button' | 'link' | 'drop-down' = 'button';
+
   /**
    * Optional URL to direct the user to when the breadcrumb item is activated. When set, a link will be rendered
    * internally. When unset, a button will be rendered instead.
@@ -43,9 +47,15 @@ export default class SlBreadcrumbItem extends ShoelaceElement {
   /** The `rel` attribute to use on the link. Only used when `href` is set. */
   @property() rel = 'noreferrer noopener';
 
-  render() {
-    const isLink = this.href ? true : false;
+  handleSlotChange() {
+    const hasDropdown =
+      this.defaultSlot.assignedElements({ flatten: true }).filter(i => i.tagName.toLowerCase() === 'sl-dropdown')
+        .length > 0;
 
+    this.renderType = this.href ? 'link' : hasDropdown ? 'drop-down' : 'button';
+  }
+
+  render() {
     return html`
       <div
         part="base"
@@ -59,7 +69,7 @@ export default class SlBreadcrumbItem extends ShoelaceElement {
           <slot name="prefix"></slot>
         </span>
 
-        ${isLink
+        ${this.renderType === 'link'
           ? html`
               <a
                 part="label"
@@ -68,14 +78,24 @@ export default class SlBreadcrumbItem extends ShoelaceElement {
                 target="${ifDefined(this.target ? this.target : undefined)}"
                 rel=${ifDefined(this.target ? this.rel : undefined)}
               >
-                <slot></slot>
+                <slot @slotchange=${this.handleSlotChange}></slot>
               </a>
             `
-          : html`
+          : ''}
+        ${this.renderType === 'button'
+          ? html`
               <button part="label" type="button" class="breadcrumb-item__label breadcrumb-item__label--button">
-                <slot></slot>
+                <slot @slotchange=${this.handleSlotChange}></slot>
               </button>
-            `}
+            `
+          : ''}
+        ${this.renderType === 'drop-down'
+          ? html`
+              <div part="label" class="breadcrumb-item__label breadcrumb-item__label--drop-down">
+                <slot @slotchange=${this.handleSlotChange}></slot>
+              </div>
+            `
+          : ''}
 
         <span part="suffix" class="breadcrumb-item__suffix">
           <slot name="suffix"></slot>

--- a/src/components/breadcrumb-item/breadcrumb-item.component.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.component.ts
@@ -53,7 +53,17 @@ export default class SlBreadcrumbItem extends ShoelaceElement {
       this.defaultSlot.assignedElements({ flatten: true }).filter(i => i.tagName.toLowerCase() === 'sl-dropdown')
         .length > 0;
 
-    this.renderType = this.href ? 'link' : hasDropdown ? 'drop-down' : 'button';
+   if (this.href) {
+      this.renderType = "link"
+      return
+   }
+
+   if (hasDropdown) {
+     this.renderType = "dropdown"
+     return
+   }
+
+   this.renderType = "button"
   }
 
   @watch('href', { waitUntilFirstUpdate: true })

--- a/src/components/breadcrumb-item/breadcrumb-item.component.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.component.ts
@@ -109,7 +109,7 @@ export default class SlBreadcrumbItem extends ShoelaceElement {
               </button>
             `
           : ''}
-        ${this.renderType === 'drop-down'
+        ${this.renderType === 'dropdown'
           ? html`
               <div part="label" class="breadcrumb-item__label breadcrumb-item__label--drop-down">
                 <slot @slotchange=${this.handleSlotChange}></slot>

--- a/src/components/breadcrumb-item/breadcrumb-item.component.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.component.ts
@@ -53,17 +53,17 @@ export default class SlBreadcrumbItem extends ShoelaceElement {
       this.defaultSlot.assignedElements({ flatten: true }).filter(i => i.tagName.toLowerCase() === 'sl-dropdown')
         .length > 0;
 
-   if (this.href) {
-      this.renderType = "link"
-      return
-   }
+    if (this.href) {
+      this.renderType = 'link';
+      return;
+    }
 
-   if (hasDropdown) {
-     this.renderType = "dropdown"
-     return
-   }
+    if (hasDropdown) {
+      this.renderType = 'dropdown';
+      return;
+    }
 
-   this.renderType = "button"
+    this.renderType = 'button';
   }
 
   @watch('href', { waitUntilFirstUpdate: true })

--- a/src/components/breadcrumb-item/breadcrumb-item.test.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.test.ts
@@ -103,6 +103,30 @@ describe('<sl-breadcrumb-item>', () => {
     });
   });
 
+  describe('when rendering a sl-dropdown in the default slot', () => {
+    it('should not render a link or button tag, but a div wrapper', async () => {
+      el = await fixture<SlBreadcrumbItem>(html`
+        <sl-breadcrumb-item>
+          <sl-dropdown>
+            <sl-button slot="trigger" size="small" circle>
+              <sl-icon label="More options" name="three-dots"></sl-icon>
+            </sl-button>
+            <sl-menu>
+              <sl-menu-item type="checkbox" checked>Web Design</sl-menu-item>
+              <sl-menu-item type="checkbox">Web Development</sl-menu-item>
+              <sl-menu-item type="checkbox">Marketing</sl-menu-item>
+            </sl-menu>
+          </sl-dropdown>
+        </sl-breadcrumb-item>
+      `);
+
+      await expect(el).to.be.accessible();
+      expect(el.shadowRoot!.querySelector('a')).to.be.null;
+      expect(el.shadowRoot!.querySelector('button')).to.be.null;
+      expect(el.shadowRoot!.querySelector('div.breadcrumb-item__label--drop-down')).not.to.be.null;
+    });
+  });
+
   describe('when provided an element in the slot "prefix" to support prefix icons', () => {
     before(async () => {
       el = await fixture<SlBreadcrumbItem>(html`


### PR DESCRIPTION
This PR adds the ability to add `<sl-dropdown>` in the default slot of a `<sl-breadcrumb-item>` as requested and discussed in https://github.com/shoelace-style/shoelace/discussions/2011, this feature.

The following changes where made to make this work:

The `render` call does not rely on the `href` attribute alone to render. Instead, a new state `renderType` is created that may hold one of the following values: `'button' | 'link' | 'drop-down'`. As before, it defaults to `button`, making all original examples work.

A `slotChange` listener is bound to all default slots that checks for availability of a slotted `<sl-dropdown>`. If one is found, the render type is set to `drop-down`. In all other cases, the logic from the original rendering applies.

I also have added tests and updated the documentation. However, I am unsure how to document this. Should we leave the initial example as is or create a new one (which I did in this PR)?

Looking forward to your suggestions.
