### PR TITLE
fix: registering sl-radio twice

### DIFF
--- a/src/components/radio/radio.component.ts
+++ b/src/components/radio/radio.component.ts
@@ -116,9 +116,3 @@ export default class SlRadio extends ShoelaceElement {
     `;
   }
 }
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'sl-radio': SlRadio;
-  }
-}


### PR DESCRIPTION
Fixes `sl-radio` being registered twice. Both `radio.component.ts` and `radio.ts` are registering `sl-radio`.

According to the installation [docs](https://shoelace.style/getting-started/installation#avoiding-auto-registering-imports), the `*.component.ts` file should only export the class, and `*.ts` should register the component.