### PR TITLE
add specified file hint in vue guide

### DIFF
--- a/docs/pages/frameworks/vue.md
+++ b/docs/pages/frameworks/vue.md
@@ -23,6 +23,7 @@ npm install @shoelace-style/shoelace
 Next, [include a theme](/getting-started/themes) and set the [base path](/getting-started/installation#setting-the-base-path) for icons and other assets. In this example, we'll import the light theme and use the CDN as a base path.
 
 ```jsx
+// main.js or main.ts
 import '@shoelace-style/shoelace/dist/themes/light.css';
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path';
 


### PR DESCRIPTION
It's not clear In [Vue Guide](https://shoelace.style/frameworks/vue#installation), the user may not know where to apply the theme and base path set, so I add file hint like [React Guide](https://shoelace.style/frameworks/react#installation)
![image](https://github.com/shoelace-style/shoelace/assets/63441399/2e059852-6d5e-4b23-836a-df7023019145)
![image](https://github.com/shoelace-style/shoelace/assets/63441399/7eabd0a5-4e82-4634-ac67-875e3e208c39)
