### PR TITLE
chore(docs) - reduce build time

### DIFF
--- a/docs/_utilities/replacer.cjs
+++ b/docs/_utilities/replacer.cjs
@@ -9,11 +9,14 @@
  */
 
 /**
- * @param {Document} content
+ * @param {String} rawContent
  * @param {Replacements} replacements
  */
-module.exports = function (content, replacements) {
+module.exports = function (rawContent, replacements) {
+  let content = rawContent;
   replacements.forEach(replacement => {
-    content.body.innerHTML = content.body.innerHTML.replaceAll(replacement.pattern, replacement.replacement);
+    content = content.replaceAll(replacement.pattern, replacement.replacement);
   });
+
+  return content;
 };

--- a/docs/eleventy.config.cjs
+++ b/docs/eleventy.config.cjs
@@ -115,7 +115,13 @@ module.exports = function (eleventyConfig) {
   //
   // Transforms
   //
-  eleventyConfig.addTransform('html-transform', function (content) {
+  eleventyConfig.addTransform('html-transform', function (rawContent) {
+    let content = replacer(rawContent, [
+      { pattern: '%VERSION%', replacement: customElementsManifest.package.version },
+      { pattern: '%CDNDIR%', replacement: cdndir },
+      { pattern: '%NPMDIR%', replacement: npmdir }
+    ]);
+
     // Parse the template and get a Document object
     const doc = new JSDOM(content, {
       // We must set a default URL so links are parsed with a hostname. Let's use a bogus TLD so we can easily
@@ -140,11 +146,6 @@ module.exports = function (eleventyConfig) {
     scrollingTables(doc);
     copyCodeButtons(doc); // must be after codePreviews + highlightCodeBlocks
     typography(doc, '#content');
-    replacer(doc, [
-      { pattern: '%VERSION%', replacement: customElementsManifest.package.version },
-      { pattern: '%CDNDIR%', replacement: cdndir },
-      { pattern: '%NPMDIR%', replacement: npmdir }
-    ]);
 
     // Serialize the Document object to an HTML string and prepend the doctype
     content = `<!DOCTYPE html>\n${doc.documentElement.outerHTML}`;


### PR DESCRIPTION
reduce build times by using string replace instead of JSDOM innerHTML.

Example from my system:

Before (14025ms):
```bash
> time npm run build

[11ty] Benchmark 14025ms 62%    85× (Configuration) "html-transform" Transform

[11ty] Copied 32 files / Wrote 85 files in 22.25 seconds (261.8ms each, v2.0.1)

npm run build  0.01s user 0.02s system 0% cpu 37.450 total
```

After (5021ms):
```bash
> time npm run build

[11ty] Benchmark   5021ms  39%    85× (Configuration) "html-transform" Transform

[11ty] Copied 32 files / Wrote 85 files in 12.75 seconds (150.0ms each, v2.0.1)

npm run build  0.01s user 0.02s system 0% cpu 28.081 total
```