### PR TITLE
Exported the popup part of the dropdown component

### DIFF
--- a/src/components/dropdown/dropdown.component.ts
+++ b/src/components/dropdown/dropdown.component.ts
@@ -34,7 +34,8 @@ import type SlMenu from '../menu/menu.js';
  * @event sl-hide - Emitted when the dropdown closes.
  * @event sl-after-hide - Emitted after the dropdown closes and all animations are complete.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - The component's base wrapper, an `<sl-popup>` element.
+ * @csspart base__popup - The popup's exported `popup` part. Use this to target the tooltip's popup container.
  * @csspart trigger - The container that wraps the trigger.
  * @csspart panel - The panel that gets shown when the dropdown is open.
  *
@@ -406,6 +407,7 @@ export default class SlDropdown extends ShoelaceElement {
     return html`
       <sl-popup
         part="base"
+        exportparts="popup:base__popup"
         id="dropdown"
         placement=${this.placement}
         distance=${this.distance}


### PR DESCRIPTION
With the minor changes, as requested here #2076, it is now possible to style the popup in the nested shadow tree within the `<sl-dropdown>` component.

See example below:
```
<style>
  sl-dropdown::part(base__popup) {
    opacity: 0.75;
  }
</style>
```

<img src="https://github.com/shoelace-style/shoelace/assets/58339654/586f2f6e-ad44-4025-b2b2-6e33dcb11837" width="300">