### PR TITLE
Increase contrast of interactive element borders in dark mode

### DIFF
--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -77,13 +77,13 @@ export default css`
   /* Default */
   .button--standard.button--default {
     background-color: var(--sl-color-neutral-0);
-    border-color: var(--sl-color-neutral-400);
+    border-color: var(--sl-input-border-color);
     color: var(--sl-color-neutral-700);
   }
 
   .button--standard.button--default:hover:not(.button--disabled) {
     background-color: var(--sl-color-primary-50);
-    border-color: var(--sl-color-primary-400);
+    border-color: var(--sl-color-primary-300);
     color: var(--sl-color-primary-700);
   }
 
@@ -198,7 +198,7 @@ export default css`
 
   /* Default */
   .button--outline.button--default {
-    border-color: var(--sl-color-neutral-300);
+    border-color: var(--sl-input-border-color);
     color: var(--sl-color-neutral-700);
   }
 

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -77,13 +77,13 @@ export default css`
   /* Default */
   .button--standard.button--default {
     background-color: var(--sl-color-neutral-0);
-    border-color: var(--sl-color-neutral-300);
+    border-color: var(--sl-color-neutral-400);
     color: var(--sl-color-neutral-700);
   }
 
   .button--standard.button--default:hover:not(.button--disabled) {
     background-color: var(--sl-color-primary-50);
-    border-color: var(--sl-color-primary-300);
+    border-color: var(--sl-color-primary-400);
     color: var(--sl-color-primary-700);
   }
 

--- a/src/components/tag/tag.styles.ts
+++ b/src/components/tag/tag.styles.ts
@@ -46,7 +46,7 @@ export default css`
 
   .tag--neutral {
     background-color: var(--sl-color-neutral-50);
-    border-color: var(--sl-color-neutral-300);
+    border-color: var(--sl-color-neutral-200);
     color: var(--sl-color-neutral-800);
   }
 

--- a/src/components/tag/tag.styles.ts
+++ b/src/components/tag/tag.styles.ts
@@ -46,7 +46,7 @@ export default css`
 
   .tag--neutral {
     background-color: var(--sl-color-neutral-50);
-    border-color: var(--sl-color-neutral-200);
+    border-color: var(--sl-color-neutral-300);
     color: var(--sl-color-neutral-800);
   }
 

--- a/src/themes/dark.css
+++ b/src/themes/dark.css
@@ -427,10 +427,10 @@
   --sl-input-background-color-hover: var(--sl-input-background-color);
   --sl-input-background-color-focus: var(--sl-input-background-color);
   --sl-input-background-color-disabled: var(--sl-color-neutral-100);
-  --sl-input-border-color: var(--sl-color-neutral-300);
-  --sl-input-border-color-hover: var(--sl-color-neutral-400);
-  --sl-input-border-color-focus: var(--sl-color-primary-500);
-  --sl-input-border-color-disabled: var(--sl-color-neutral-300);
+  --sl-input-border-color: var(--sl-color-neutral-400);
+  --sl-input-border-color-hover: var(--sl-color-neutral-500);
+  --sl-input-border-color-focus: var(--sl-color-primary-600);
+  --sl-input-border-color-disabled: var(--sl-color-neutral-400);
   --sl-input-border-width: 1px;
   --sl-input-required-content: '*';
   --sl-input-required-content-offset: -2px;


### PR DESCRIPTION
Addresses issue #2091.

These changes bump up the contrast between the default background color and button + input border colors in dark mode. While this doesn't quite meet [WCAG 2.1 Non-text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast) recommendations, it is a noticeable improvement without being drastically different for current Shoelace users. Web Awesome will (and does) have a stronger adherence to non-text contrast recommendations.

With this PR, default button borders now match the theme's input border color.