### PR TITLE
Increase contrast of help text in dark mode

### DIFF
--- a/src/themes/dark.css
+++ b/src/themes/dark.css
@@ -482,7 +482,7 @@
   --sl-input-help-text-font-size-small: var(--sl-font-size-x-small);
   --sl-input-help-text-font-size-medium: var(--sl-font-size-small);
   --sl-input-help-text-font-size-large: var(--sl-font-size-medium);
-  --sl-input-help-text-color: var(--sl-color-neutral-500);
+  --sl-input-help-text-color: var(--sl-color-neutral-600);
 
   /* Toggles (checkboxes, radios, switches) */
   --sl-toggle-size-small: 0.875rem; /* 14px */


### PR DESCRIPTION
Addresses [an additional comment](https://github.com/shoelace-style/shoelace/issues/2091#issuecomment-2205077122) on issue #2091.

This super-simple change brings the contrast ratio of help text against the default background in the dark theme up from 3.33:1 to 5.35:1.