### PR TITLE
Fix wrong name of css property of alert component in docs

### DIFF
--- a/docs/pages/tokens/z-index.md
+++ b/docs/pages/tokens/z-index.md
@@ -13,5 +13,5 @@ Z-indexes are used to stack components in a logical manner.
 | `--sl-z-index-drawer`      | 700   |
 | `--sl-z-index-dialog`      | 800   |
 | `--sl-z-index-dropdown`    | 900   |
-| `--sl-z-index-alert-group` | 950   |
+| `--sl-z-index-toast`       | 950   |
 | `--sl-z-index-tooltip`     | 1000  |


### PR DESCRIPTION
There was an old property name in the docs that's not used in the code anymore. I changed it to the current one.