### PR TITLE
Fix carousel newActiveSlide calculation to account for slidesPerPage

### DIFF
--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -461,9 +461,17 @@ export default class SlCarousel extends ShoelaceElement {
       : clamp(index, 0, slides.length - slidesPerPage);
     this.activeSlide = newActiveSlide;
 
+    const isRtl = this.matches(':dir(rtl)');
+
     // Get the index of the next slide. For looping carousel it adds `slidesPerPage`
     // to normalize the starting index in order to ignore the first nth clones.
-    const nextSlideIndex = clamp(index + (loop ? slidesPerPage : 0), 0, slidesWithClones.length - slidesPerPage);
+    // For RTL it needs to scroll to the last slide of the page.
+    const nextSlideIndex = clamp(
+      index + (loop ? slidesPerPage : 0) + (isRtl ? slidesPerPage - 1 : 0),
+      0,
+      slidesWithClones.length - 1
+    );
+
     const nextSlide = slidesWithClones[nextSlideIndex];
 
     this.scrollToSlide(nextSlide, prefersReducedMotion() ? 'auto' : behavior);

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -456,12 +456,14 @@ export default class SlCarousel extends ShoelaceElement {
     }
 
     // Sets the next index without taking into account clones, if any.
-    const newActiveSlide = loop ? (index + slides.length) % slides.length : clamp(index, 0, slides.length - 1);
+    const newActiveSlide = loop
+      ? (index + slides.length) % slides.length
+      : clamp(index, 0, slides.length - slidesPerPage);
     this.activeSlide = newActiveSlide;
 
     // Get the index of the next slide. For looping carousel it adds `slidesPerPage`
     // to normalize the starting index in order to ignore the first nth clones.
-    const nextSlideIndex = clamp(index + (loop ? slidesPerPage : 0), 0, slidesWithClones.length - 1);
+    const nextSlideIndex = clamp(index + (loop ? slidesPerPage : 0), 0, slidesWithClones.length - slidesPerPage);
     const nextSlide = slidesWithClones[nextSlideIndex];
 
     this.scrollToSlide(nextSlide, prefersReducedMotion() ? 'auto' : behavior);


### PR DESCRIPTION
Navigating with the arrow key after reaching the last page leads to visual bugs with the pagination. This is because it tries to set newActiveSlide to a value too large if slidesPerPage is larger than 1.

Here is a video:
https://github.com/user-attachments/assets/6a1a7091-9ea7-46aa-ad2f-5ba1eee43536

After the fix:
https://github.com/user-attachments/assets/a59012bd-c4ec-416a-bbfc-d7d11d4a1497

~~I'm not sure if the change in line 466 is necessary.~~

Edit:
I also added a fix for https://github.com/shoelace-style/shoelace/issues/1989.