### PR TITLE
fix(#2151): use button element for link button when disabled

### DIFF
--- a/src/components/button/button.component.ts
+++ b/src/components/button/button.component.ts
@@ -256,7 +256,7 @@ export default class SlButton extends ShoelaceElement implements ShoelaceFormCon
 
   render() {
     const isLink = this.isLink();
-    const tag = isLink ? literal`a` : literal`button`;
+    const tag = (isLink && !this.disabled) ? literal`a` : literal`button`;
 
     /* eslint-disable lit/no-invalid-html */
     /* eslint-disable lit/binding-positions */


### PR DESCRIPTION
To address #2151 

According to the HTML spec, the `<a>` tag does not support the disabled attribute. 

In this PR I am proposing to revert to using the `<button>` element for a disabled link-button. While this seems to address the issue, the compromise being made is that the `href` attribute is tacked onto the button. This may not be semantically correct. The other alternative is to unset the href attribute itself.

What would you suggest? Does this approach work? 