### PR TITLE
[fix][CVE-2024-27307] update jsonata dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "globby": "^13.2.2",
         "husky": "^8.0.3",
         "jsdom": "^22.1.0",
-        "jsonata": "^2.0.3",
+        "jsonata": "^2.0.4",
         "lint-staged": "^14.0.1",
         "lunr": "^2.3.9",
         "markdown-it-container": "^3.0.0",
@@ -11312,10 +11312,11 @@
       }
     },
     "node_modules/jsonata": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.3.tgz",
-      "integrity": "sha512-Up2H81MUtjqI/dWwWX7p4+bUMfMrQJVMN/jW6clFMTiYP528fBOBNtRu944QhKTs3+IsVWbgMeUTny5fw2VMUA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.5.tgz",
+      "integrity": "sha512-wEse9+QLIIU5IaCgtJCPsFi/H4F3qcikWzF4bAELZiRz08ohfx3Q6CjDRf4ZPF5P/92RI3KIHtb7u3jqPaHXdQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -27299,9 +27300,9 @@
       "dev": true
     },
     "jsonata": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.3.tgz",
-      "integrity": "sha512-Up2H81MUtjqI/dWwWX7p4+bUMfMrQJVMN/jW6clFMTiYP528fBOBNtRu944QhKTs3+IsVWbgMeUTny5fw2VMUA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.5.tgz",
+      "integrity": "sha512-wEse9+QLIIU5IaCgtJCPsFi/H4F3qcikWzF4bAELZiRz08ohfx3Q6CjDRf4ZPF5P/92RI3KIHtb7u3jqPaHXdQ==",
       "dev": true
     },
     "jsonfile": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "globby": "^13.2.2",
     "husky": "^8.0.3",
     "jsdom": "^22.1.0",
-    "jsonata": "^2.0.3",
+    "jsonata": "^2.0.4",
     "lint-staged": "^14.0.1",
     "lunr": "^2.3.9",
     "markdown-it-container": "^3.0.0",


### PR DESCRIPTION
This is a minor change bumping `jsonata` following security advisory note that tagged this package vulnerability as `critical`:
https://www.cve.org/CVERecord?id=CVE-2024-27307
https://github.com/jsonata-js/jsonata/security/advisories/GHSA-fqg8-vfv7-8fj8

Thanks!