### PR TITLE
Issue 2117: Fix sl-select throws exception if a sl-input in the same form receives a new value with autofill in MS Edge

### DIFF
--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -373,7 +373,7 @@ export default class SlSelect extends ShoelaceElement implements ShoelaceFormCon
     }
 
     // All other "printable" keys trigger type to select
-    if (event.key.length === 1 || event.key === 'Backspace') {
+    if ((event.key && event.key.length === 1) || event.key === 'Backspace') {
       const allOptions = this.getAllOptions();
 
       // Don't block important key combos like CMD+R

--- a/src/components/select/select.test.ts
+++ b/src/components/select/select.test.ts
@@ -216,8 +216,6 @@ describe('<sl-select>', () => {
         </sl-select>
       `);
 
-      await aTimeout(0);
-
       const event = new KeyboardEvent('keydown');
       Object.defineProperty(event, 'target', { writable: false, value: el });
       Object.defineProperty(event, 'key', { writable: false, value: undefined });
@@ -626,7 +624,7 @@ describe('<sl-select>', () => {
         );
         const el = form.querySelector<SlSelect>('sl-select')!;
 
-        await aTimeout(0);
+        await aTimeout(10);
         expect(el.value).to.equal('');
         expect(new FormData(form).get('select')).equal('');
 

--- a/src/components/select/select.test.ts
+++ b/src/components/select/select.test.ts
@@ -206,6 +206,31 @@ describe('<sl-select>', () => {
 
       expect(handler).to.be.calledTwice;
     });
+
+    // this can happen in on ms-edge autofilling an associated input element in the same form
+    // https://github.com/shoelace-style/shoelace/issues/2117
+    it('should not throw on incomplete events', async () => {
+      const el = await fixture<SlSelect>(html`
+        <sl-select required>
+          <sl-option value="option-1">Option 1</sl-option>
+        </sl-select>
+      `);
+
+      await aTimeout(0);
+
+      const event = new KeyboardEvent('keydown');
+      Object.defineProperty(event, 'target', { writable: false, value: el });
+      Object.defineProperty(event, 'key', { writable: false, value: undefined });
+
+      /**
+       * If Edge does autofill, it creates a broken KeyboardEvent
+       * which is missing the key value.
+       * Using the normal dispatch mechanism does not allow to do this
+       * Thus passing the event directly to the private method for testing
+       *
+       * @ts-expect-error */
+      el.handleDocumentKeyDown(event);
+    });
   });
 
   it('should open the listbox when any letter key is pressed with sl-select is on focus', async () => {
@@ -601,7 +626,7 @@ describe('<sl-select>', () => {
         );
         const el = form.querySelector<SlSelect>('sl-select')!;
 
-        await aTimeout(10);
+        await aTimeout(0);
         expect(el.value).to.equal('');
         expect(new FormData(form).get('select')).equal('');
 


### PR DESCRIPTION
Fixed the TypeError by adding an additional check that the key property exists.
Also added a test checking this behavior.