### PR TITLE
Create pt-br.ts translation

### DIFF
--- a/src/translations/pt-br.ts
+++ b/src/translations/pt-br.ts
@@ -1,0 +1,13 @@
+import { registerTranslation } from '../utilities/localize.js';
+import baseTranslation from './pt.js';
+import type { Translation } from '../utilities/localize.js';
+
+const translation: Translation = {
+  ...baseTranslation,
+  $code: 'pt-BR',
+  $name: 'Português (Brasil)',
+};
+
+registerTranslation(translation);
+
+export default translation;


### PR DESCRIPTION
For now, the current Portuguese file from Portugal is consistent with Brazilian Portuguese (I extended it), however it is good to already have the file created to facilitate the insertion of future translations where the similarity ends.