### PR TITLE
`SlTooltip` call `super.disconnectedCallback()`

### DIFF
--- a/src/components/tooltip/tooltip.component.ts
+++ b/src/components/tooltip/tooltip.component.ts
@@ -109,6 +109,7 @@ export default class SlTooltip extends ShoelaceElement {
   }
 
   disconnectedCallback() {
+    super.disconnectedCallback();
     // Cleanup this event in case the tooltip is removed while open
     this.closeWatcher?.destroy();
     document.removeEventListener('keydown', this.handleDocumentKeyDown);


### PR DESCRIPTION
`SlTooltip` has a `disconnectedCallback()` function which isn't calling `super.disconnectedCallback()` resulting in a memory leak for disconnected `<sl-tooltip>` elements (reference held by `connectedElements` in `LocalizeController`). This simply adds the `super.disconnectedCallback()` call in.