### PR TITLE
fix(carousel): navigation arrow directionality for ltr/rtl

### DIFF
--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -512,7 +512,7 @@ export default class SlCarousel extends ShoelaceElement {
     const currentPage = this.getCurrentPage();
     const prevEnabled = this.canScrollPrev();
     const nextEnabled = this.canScrollNext();
-    const isLtr = this.localize.dir() === 'rtl';
+    const isRtl = this.localize.dir() === 'rtl';
 
     return html`
       <div part="base" class="carousel">
@@ -553,7 +553,7 @@ export default class SlCarousel extends ShoelaceElement {
                   @click=${prevEnabled ? () => this.previous() : null}
                 >
                   <slot name="previous-icon">
-                    <sl-icon library="system" name="${isLtr ? 'chevron-left' : 'chevron-right'}"></sl-icon>
+                    <sl-icon library="system" name="${isRtl ? 'chevron-right' : 'chevron-left'}"></sl-icon>
                   </slot>
                 </button>
 
@@ -570,7 +570,7 @@ export default class SlCarousel extends ShoelaceElement {
                   @click=${nextEnabled ? () => this.next() : null}
                 >
                   <slot name="next-icon">
-                    <sl-icon library="system" name="${isLtr ? 'chevron-right' : 'chevron-left'}"></sl-icon>
+                    <sl-icon library="system" name="${isRtl ? 'chevron-left' : 'chevron-right'}"></sl-icon>
                   </slot>
                 </button>
               </div>


### PR DESCRIPTION
This PR resolves an issue where the carousel navigation arrows were displayed incorrectly for LTR and RTL directionality

| Before | After | 
| --- | --- | 
| ![before](https://github.com/user-attachments/assets/ac34b33b-859a-4bf9-a495-6a2fe9f80d2b) | ![after](https://github.com/user-attachments/assets/40803d38-8a4d-4612-9b51-a3d9c89103a0) | 