### PR TITLE
fix color picker property naming

### DIFF
--- a/src/components/color-picker/color-picker.component.ts
+++ b/src/components/color-picker/color-picker.component.ts
@@ -1053,7 +1053,7 @@ export default class SlColorPicker extends ShoelaceElement implements ShoelaceFo
       <sl-dropdown
         class="color-dropdown"
         aria-disabled=${this.disabled ? 'true' : 'false'}
-        .containing-element=${this}
+        .containingElement=${this}
         ?disabled=${this.disabled}
         ?hoist=${this.hoist}
         @sl-after-hide=${this.handleAfterHide}


### PR DESCRIPTION
Problem: The containing element is defaulting to the dropdown instead of the desired color picker component. This is due to the use of the kebab naming of the property `.containing-element` in the html of the color picker.

Solution: Refactor property in html to the matching camel case.
