### PR TITLE
fix carousel item children with click handlers

### DIFF
--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -259,6 +259,13 @@ export default class SlCarousel extends ShoelaceElement {
     });
   };
 
+  @eventOptions({ capture: true })
+  private handleClick(e: MouseEvent) {
+    if (this.dragging) {
+      e.stopPropagation();
+    }
+  }
+
   @eventOptions({ passive: true })
   private handleScroll() {
     this.scrolling = true;
@@ -533,6 +540,7 @@ export default class SlCarousel extends ShoelaceElement {
           @mousedown="${this.handleMouseDragStart}"
           @scroll="${this.handleScroll}"
           @scrollend=${this.handleScrollEnd}
+          @click=${this.handleClick}
         >
           <slot></slot>
         </div>

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -262,6 +262,9 @@ export default class SlCarousel extends ShoelaceElement {
   @eventOptions({ capture: true })
   private handleClick(e: MouseEvent) {
     if (this.dragging) {
+      // prevents anchor tags within carousel items from triggering while dragging
+      e.preventDefault();
+      // prevents click events within carousel items from triggerin while dragging
       e.stopPropagation();
     }
   }


### PR DESCRIPTION
Don't trigger the click event while dragging.

Fixes #2196