### PR TITLE
fix possibly leaking eventlisteners

### DIFF
--- a/src/components/dialog/dialog.component.ts
+++ b/src/components/dialog/dialog.component.ts
@@ -114,7 +114,7 @@ export default class SlDialog extends ShoelaceElement {
     super.disconnectedCallback();
     this.modal.deactivate();
     unlockBodyScrolling(this);
-    this.closeWatcher?.destroy();
+    this.removeOpenListeners();
   }
 
   private requestClose(source: 'close-button' | 'keyboard' | 'overlay') {

--- a/src/components/drawer/drawer.component.ts
+++ b/src/components/drawer/drawer.component.ts
@@ -131,7 +131,7 @@ export default class SlDrawer extends ShoelaceElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     unlockBodyScrolling(this);
-    this.closeWatcher?.destroy();
+    this.removeOpenListeners();
   }
 
   private requestClose(source: 'close-button' | 'keyboard' | 'overlay') {


### PR DESCRIPTION
`Dialog` and `Drawer` do not clean up the keyboard event listener in disconnectedCallback. This might lead to an issue in SPAs when linking away from within an opened Dialog or Drawer. The issue only exists for Browsers that don't support the CloseWatcher API.

In this case, there's even a function called removeOpenListeners which can be called on disconnectedCallback. This already solves the whole issue.

This resembles the implementation in the Dropdown Component (https://github.com/shoelace-style/shoelace/blob/next/src/components/dropdown/dropdown.component.ts#L132)