### PR TITLE
Adds Norwegian translations

### DIFF
--- a/src/translations/nb.ts
+++ b/src/translations/nb.ts
@@ -1,0 +1,39 @@
+import { registerTranslation } from '../utilities/localize.js';
+import type { Translation } from "../utilities/localize.js";
+
+const translation: Translation = {
+  $code: 'nb',
+  $name: 'Norwegian Bokmål',
+  $dir: 'ltr',
+
+  carousel: 'Karusell',
+  clearEntry: 'Tøm felt',
+  close: 'Lukk',
+  copied: 'Kopiert',
+  copy: 'Kopier',
+  currentValue: 'Nåværende verdi',
+  error: 'Feil',
+  goToSlide: (slide, count) => `Gå til visning ${slide} av ${count}`,
+  hidePassword: 'Skjul passord',
+  loading: 'Laster',
+  nextSlide: 'Neste visning',
+  numOptionsSelected: num => {
+    if (num === 0) return 'Ingen alternativer valgt';
+    if (num === 1) return 'Ett alternativ valgt';
+    return `${num} alternativer valgt`;
+  },
+  previousSlide: 'Forrige visning',
+  progress: 'Fremdrift',
+  remove: 'Fjern',
+  resize: 'Endre størrelse',
+  scrollToEnd: 'Rull til slutten',
+  scrollToStart: 'Rull til starten',
+  selectAColorFromTheScreen: 'Velg en farge fra skjermen',
+  showPassword: 'Vis passord',
+  slideNum: slide => `Visning ${slide}`,
+  toggleColorFormat: 'Bytt fargeformat'
+};
+
+registerTranslation(translation);
+
+export default translation;

--- a/src/translations/nn.ts
+++ b/src/translations/nn.ts
@@ -1,0 +1,39 @@
+import { registerTranslation } from '../utilities/localize.js';
+import type { Translation } from "../utilities/localize.js";
+
+const translation: Translation = {
+  $code: 'nn',
+  $name: 'Norwegian Nynorsk',
+  $dir: 'ltr',
+
+  carousel: 'Karusell',
+  clearEntry: 'Tøm felt',
+  close: 'Lukk',
+  copied: 'Kopiert',
+  copy: 'Kopier',
+  currentValue: 'Nåverande verdi',
+  error: 'Feil',
+  goToSlide: (slide, count) => `Gå til visning ${slide} av ${count}`,
+  hidePassword: 'Gøym passord',
+  loading: 'Lastar',
+  nextSlide: 'Neste visning',
+  numOptionsSelected: num => {
+    if (num === 0) return 'Ingen alternativ valt';
+    if (num === 1) return 'Eitt alternativ valt';
+    return `${num} alternativ valt`;
+  },
+  previousSlide: 'Førre visning',
+  progress: 'Framdrift',
+  remove: 'Fjern',
+  resize: 'Endre storleik',
+  scrollToEnd: 'Rull til slutten',
+  scrollToStart: 'Rull til starten',
+  selectAColorFromTheScreen: 'Vel ein farge frå skjermen',
+  showPassword: 'Vis passord',
+  slideNum: slide => `Visning ${slide}`,
+  toggleColorFormat: 'Byt fargeformat'
+};
+
+registerTranslation(translation);
+
+export default translation;


### PR DESCRIPTION
Adds norwegian translations for both Bokmål and Nynorsk. 
I've used the [ISO 639-1 Code](https://www.loc.gov/standards/iso639-2/php/code_list.php) for both, as it seems to be preferred over the dialect-codes if a 2-letter code exists.