### PR TITLE
Fix rendering performance bottleneck in carousel

### DIFF
--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -506,20 +506,27 @@ export default class SlCarousel extends ShoelaceElement {
   }
 
   private scrollToSlide(slide: HTMLElement, behavior: ScrollBehavior = 'smooth') {
-    const scrollContainer = this.scrollContainer;
-    const scrollContainerRect = scrollContainer.getBoundingClientRect();
-    const nextSlideRect = slide.getBoundingClientRect();
-
-    const nextLeft = nextSlideRect.left - scrollContainerRect.left;
-    const nextTop = nextSlideRect.top - scrollContainerRect.top;
-
-    if (nextLeft || nextTop) {
-      this.pendingSlideChange = true;
-      scrollContainer.scrollTo({
-        left: nextLeft + scrollContainer.scrollLeft,
-        top: nextTop + scrollContainer.scrollTop,
-        behavior
-      });
+    const doWork = () => {
+      const scrollContainer = this.scrollContainer;
+      const scrollContainerRect = scrollContainer.getBoundingClientRect();
+      const nextSlideRect = slide.getBoundingClientRect();
+      
+      const nextLeft = nextSlideRect.left - scrollContainerRect.left;
+      const nextTop = nextSlideRect.top - scrollContainerRect.top;
+      
+      if (nextLeft || nextTop) {
+        this.pendingSlideChange = true;
+        scrollContainer.scrollTo({
+          left: nextLeft + scrollContainer.scrollLeft,
+          top: nextTop + scrollContainer.scrollTop,
+          behavior
+        });
+      }
+    }
+    if ('requestAnimationFrame' in window) {
+      window.requestAnimationFrame(doWork);
+    } else {
+      doWork();
     }
   }
 

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -506,6 +506,9 @@ export default class SlCarousel extends ShoelaceElement {
   }
 
   private scrollToSlide(slide: HTMLElement, behavior: ScrollBehavior = 'smooth') {
+    // Since the geometry doesn't happen until rAF, we don't know if we'll be scrolling or not...
+    // It's best to assume that we will and cleanup in the else case below if we didn't need to
+    this.pendingSlideChange = true;
     window.requestAnimationFrame(() => {
       const scrollContainer = this.scrollContainer;
       const scrollContainerRect = scrollContainer.getBoundingClientRect();
@@ -515,12 +518,16 @@ export default class SlCarousel extends ShoelaceElement {
       const nextTop = nextSlideRect.top - scrollContainerRect.top;
       
       if (nextLeft || nextTop) {
+        // This is here just in case someone set it back to false
+        // between rAF being requested and the callback actually running
         this.pendingSlideChange = true;
         scrollContainer.scrollTo({
           left: nextLeft + scrollContainer.scrollLeft,
           top: nextTop + scrollContainer.scrollTop,
           behavior
         });
+      } else {
+        this.pendingSlideChange = false;
       }
     });
   }

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -506,7 +506,7 @@ export default class SlCarousel extends ShoelaceElement {
   }
 
   private scrollToSlide(slide: HTMLElement, behavior: ScrollBehavior = 'smooth') {
-    const doWork = () => {
+    window.requestAnimationFrame(() => {
       const scrollContainer = this.scrollContainer;
       const scrollContainerRect = scrollContainer.getBoundingClientRect();
       const nextSlideRect = slide.getBoundingClientRect();
@@ -522,12 +522,7 @@ export default class SlCarousel extends ShoelaceElement {
           behavior
         });
       }
-    }
-    if ('requestAnimationFrame' in window) {
-      window.requestAnimationFrame(doWork);
-    } else {
-      doWork();
-    }
+    });
   }
 
   render() {


### PR DESCRIPTION
Fixes #2280 

### Before
![Screenshot 2024-11-22 at 4 00 41 PM](https://github.com/user-attachments/assets/aed1d4c3-60a0-4802-a4ac-033837dffd95)

### After
![Screenshot 2024-11-22 at 4 03 14 PM](https://github.com/user-attachments/assets/0173037a-31d1-407d-8782-25ef60a73de7)

Notice how none of the carousels on the right side have any synchronous Layout anymore, but the browser does one big layout once in the requestAnimationFrame callback.

NOTE: The scales on these screenshots are not the same...but the key point to notice is there there aren't as many tiny red dog-ears on each of the individual carousels which is the concern I was trying to fix.