### PR TITLE
Fix sl-select padding issue with multiple and placeholder options combined

### DIFF
--- a/src/components/select/select.styles.ts
+++ b/src/components/select/select.styles.ts
@@ -209,7 +209,7 @@ export default css`
     margin-inline-start: var(--sl-input-spacing-medium);
   }
 
-  .select--medium.select--multiple .select__combobox {
+  .select--medium.select--multiple:not(.select--placeholder-visible) .select__combobox {
     padding-inline-start: 0;
     padding-block: 3px;
   }
@@ -238,7 +238,7 @@ export default css`
     margin-inline-start: var(--sl-input-spacing-large);
   }
 
-  .select--large.select--multiple .select__combobox {
+  .select--large.select--multiple:not(.select--placeholder-visible) .select__combobox {
     padding-inline-start: 0;
     padding-block: 4px;
   }

--- a/src/components/select/select.styles.ts
+++ b/src/components/select/select.styles.ts
@@ -176,7 +176,7 @@ export default css`
     margin-inline-end: var(--sl-input-spacing-small);
   }
 
-  .select--small.select--multiple .select__prefix::slotted(*) {
+  .select--small.select--multiple:not(.select--placeholder-visible) .select__prefix::slotted(*) {
     margin-inline-start: var(--sl-input-spacing-small);
   }
 
@@ -205,7 +205,7 @@ export default css`
     margin-inline-end: var(--sl-input-spacing-medium);
   }
 
-  .select--medium.select--multiple .select__prefix::slotted(*) {
+  .select--medium.select--multiple:not(.select--placeholder-visible) .select__prefix::slotted(*) {
     margin-inline-start: var(--sl-input-spacing-medium);
   }
 
@@ -234,7 +234,7 @@ export default css`
     margin-inline-end: var(--sl-input-spacing-large);
   }
 
-  .select--large.select--multiple .select__prefix::slotted(*) {
+  .select--large.select--multiple:not(.select--placeholder-visible) .select__prefix::slotted(*) {
     margin-inline-start: var(--sl-input-spacing-large);
   }
 


### PR DESCRIPTION
### Fixes:
[#2279](https://github.com/shoelace-style/shoelace/issues/2279)
[#2291](https://github.com/shoelace-style/shoelace/issues/2291)

### Description
Updated styles so that some of the style adjustments (combobox padding and prefix margin) made to `sl-select` with `multiple` options do not get applied when the placeholder is shown

I combined the solutions to these two issues since it looks like #2279 was caused by a fix for a previous issue similar to 2291 (see: [#2194 ](https://github.com/shoelace-style/shoelace/issues/2194)).

