### PR TITLE
Fix Race Condition if goToSlide is called too early

### DIFF
--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -506,6 +506,9 @@ export default class SlCarousel extends ShoelaceElement {
   }
 
   private scrollToSlide(slide: HTMLElement, behavior: ScrollBehavior = 'smooth') {
+    // This can happen if goToSlide is called before the scroll container is rendered
+    // We will have correctly set the activeSlide in goToSlide which will get picked up when initializeSlides is called.
+    if (!this.scrollContainer) { return; }
     const scrollContainer = this.scrollContainer;
     const scrollContainerRect = scrollContainer.getBoundingClientRect();
     const nextSlideRect = slide.getBoundingClientRect();


### PR DESCRIPTION
If you try to call goToSlide after construction, but before the first render, `this.scrollContainer` can be null and you get a console error. This prevents the console error.

![Screenshot 2024-12-02 at 2 57 34 PM](https://github.com/user-attachments/assets/328b6405-3671-418a-8c21-3b3f1f0bf24d)

Fixes #2296 