### PR TITLE
Fix LICENSE file check in `make-icons.js`script

### DIFF
--- a/scripts/make-icons.js
+++ b/scripts/make-icons.js
@@ -21,7 +21,7 @@ const srcPath = `./.cache/icons/icons-${version}`;
 const url = `https://github.com/twbs/icons/archive/v${version}.zip`;
 
 try {
-  await fs.stat(`${srcPath}/LICENSE.md`);
+  await fs.stat(`${srcPath}/LICENSE`);
 } catch {
   // Download the source from GitHub (since not everything is published to npm)
   await download(url, './.cache/icons', { extract: true });


### PR DESCRIPTION
Fix for preventing the download of bootstrap icons if the LICENSE file already exists.