### PR TITLE
fix ssr for sl-alert and scrollend-polyfill

### DIFF
--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -16,8 +16,8 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 
 - Improved performance of `<sl-select>` when using a large number of options [#2318]
 - Updated the Japanese translation [#2329]
-- Adjust `<sl-alert>` to create the toast stack when used only, making it usable in SSR environments.
-- Adjust `scrollend-polyfill` so it only runs on the client to make it usable in SSR environments.
+- Adjust `<sl-alert>` to create the toast stack when used only, making it usable in SSR environments. [#2359]
+- Adjust `scrollend-polyfill` so it only runs on the client to make it usable in SSR environments. [#2359]
 
 ## 2.19.1
 

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -16,6 +16,8 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 
 - Improved performance of `<sl-select>` when using a large number of options [#2318]
 - Updated the Japanese translation [#2329]
+- Adjust `<sl-alert>` to create the toast stack when used only, making it usable in SSR environments.
+- Adjust `scrollend-polyfill` so it only runs on the client to make it usable in SSR environments.
 
 ## 2.19.1
 

--- a/src/components/alert/alert.component.ts
+++ b/src/components/alert/alert.component.ts
@@ -13,8 +13,6 @@ import SlIconButton from '../icon-button/icon-button.component.js';
 import styles from './alert.styles.js';
 import type { CSSResultGroup } from 'lit';
 
-const toastStack = Object.assign(document.createElement('div'), { className: 'sl-toast-stack' });
-
 /**
  * @summary Alerts are used to display important messages inline or as toast notifications.
  * @documentation https://shoelace.style/components/alert
@@ -49,6 +47,19 @@ export default class SlAlert extends ShoelaceElement {
   private countdownAnimation?: Animation;
   private readonly hasSlotController = new HasSlotController(this, 'icon', 'suffix');
   private readonly localize = new LocalizeController(this);
+
+  private static currentToastStack: HTMLDivElement;
+
+  private static get toastStack() {
+    console.log('called');
+    if (!this.currentToastStack) {
+      this.currentToastStack = Object.assign(document.createElement('div'), {
+        className: 'sl-toast-stack'
+      });
+      console.log('created');
+    }
+    return this.currentToastStack;
+  }
 
   @query('[part~="base"]') base: HTMLElement;
 
@@ -195,11 +206,11 @@ export default class SlAlert extends ShoelaceElement {
   async toast() {
     return new Promise<void>(resolve => {
       this.handleCountdownChange();
-      if (toastStack.parentElement === null) {
-        document.body.append(toastStack);
+      if (SlAlert.toastStack.parentElement === null) {
+        document.body.append(SlAlert.toastStack);
       }
 
-      toastStack.appendChild(this);
+      SlAlert.toastStack.appendChild(this);
 
       // Wait for the toast stack to render
       requestAnimationFrame(() => {
@@ -211,12 +222,12 @@ export default class SlAlert extends ShoelaceElement {
       this.addEventListener(
         'sl-after-hide',
         () => {
-          toastStack.removeChild(this);
+          SlAlert.toastStack.removeChild(this);
           resolve();
 
           // Remove the toast stack from the DOM when there are no more alerts
-          if (toastStack.querySelector('sl-alert') === null) {
-            toastStack.remove();
+          if (SlAlert.toastStack.querySelector('sl-alert') === null) {
+            SlAlert.toastStack.remove();
           }
         },
         { once: true }

--- a/src/components/alert/alert.component.ts
+++ b/src/components/alert/alert.component.ts
@@ -51,7 +51,6 @@ export default class SlAlert extends ShoelaceElement {
   private static currentToastStack: HTMLDivElement;
 
   private static get toastStack() {
-    console.log('called');
     if (!this.currentToastStack) {
       this.currentToastStack = Object.assign(document.createElement('div'), {
         className: 'sl-toast-stack'

--- a/src/components/alert/alert.component.ts
+++ b/src/components/alert/alert.component.ts
@@ -55,7 +55,6 @@ export default class SlAlert extends ShoelaceElement {
       this.currentToastStack = Object.assign(document.createElement('div'), {
         className: 'sl-toast-stack'
       });
-      console.log('created');
     }
     return this.currentToastStack;
   }

--- a/src/internal/scrollend-polyfill.ts
+++ b/src/internal/scrollend-polyfill.ts
@@ -26,54 +26,61 @@ const decorate = <T, M extends keyof T>(
   } as MethodOf<T, M>;
 };
 
-const isSupported = 'onscrollend' in window;
+(() => {
+  // SSR environments should not apply the polyfill
+  if (typeof window === 'undefined') {
+    return;
+  }
 
-if (!isSupported) {
-  const pointers = new Set();
-  const scrollHandlers = new WeakMap<EventTarget, EventListenerOrEventListenerObject>();
+  const isSupported = 'onscrollend' in window;
 
-  const handlePointerDown = (event: TouchEvent) => {
-    for (const touch of event.changedTouches) {
-      pointers.add(touch.identifier);
-    }
-  };
+  if (!isSupported) {
+    const pointers = new Set();
+    const scrollHandlers = new WeakMap<EventTarget, EventListenerOrEventListenerObject>();
 
-  const handlePointerUp = (event: TouchEvent) => {
-    for (const touch of event.changedTouches) {
-      pointers.delete(touch.identifier);
-    }
-  };
-
-  document.addEventListener('touchstart', handlePointerDown, true);
-  document.addEventListener('touchend', handlePointerUp, true);
-  document.addEventListener('touchcancel', handlePointerUp, true);
-
-  decorate(EventTarget.prototype, 'addEventListener', function (this: EventTarget, addEventListener, type) {
-    if (type !== 'scrollend') return;
-
-    const handleScrollEnd = debounce(() => {
-      if (!pointers.size) {
-        // If no pointer is active in the scroll area then the scroll has ended
-        this.dispatchEvent(new Event('scrollend'));
-      } else {
-        // otherwise let's wait a bit more
-        handleScrollEnd();
+    const handlePointerDown = (event: TouchEvent) => {
+      for (const touch of event.changedTouches) {
+        pointers.add(touch.identifier);
       }
-    }, 100);
+    };
 
-    addEventListener.call(this, 'scroll', handleScrollEnd, { passive: true });
-    scrollHandlers.set(this, handleScrollEnd);
-  });
+    const handlePointerUp = (event: TouchEvent) => {
+      for (const touch of event.changedTouches) {
+        pointers.delete(touch.identifier);
+      }
+    };
 
-  decorate(EventTarget.prototype, 'removeEventListener', function (this: EventTarget, removeEventListener, type) {
-    if (type !== 'scrollend') return;
+    document.addEventListener('touchstart', handlePointerDown, true);
+    document.addEventListener('touchend', handlePointerUp, true);
+    document.addEventListener('touchcancel', handlePointerUp, true);
 
-    const scrollHandler = scrollHandlers.get(this);
-    if (scrollHandler) {
-      removeEventListener.call(this, 'scroll', scrollHandler, { passive: true } as unknown as EventListenerOptions);
-    }
-  });
-}
+    decorate(EventTarget.prototype, 'addEventListener', function (this: EventTarget, addEventListener, type) {
+      if (type !== 'scrollend') return;
+
+      const handleScrollEnd = debounce(() => {
+        if (!pointers.size) {
+          // If no pointer is active in the scroll area then the scroll has ended
+          this.dispatchEvent(new Event('scrollend'));
+        } else {
+          // otherwise let's wait a bit more
+          handleScrollEnd();
+        }
+      }, 100);
+
+      addEventListener.call(this, 'scroll', handleScrollEnd, { passive: true });
+      scrollHandlers.set(this, handleScrollEnd);
+    });
+
+    decorate(EventTarget.prototype, 'removeEventListener', function (this: EventTarget, removeEventListener, type) {
+      if (type !== 'scrollend') return;
+
+      const scrollHandler = scrollHandlers.get(this);
+      if (scrollHandler) {
+        removeEventListener.call(this, 'scroll', scrollHandler, { passive: true } as unknown as EventListenerOptions);
+      }
+    });
+  }
+})();
 
 // Without an import or export, TypeScript sees vars in this file as global
 export {};


### PR DESCRIPTION
Hello Shoelace team!

We are currently in the works of creating an SSR compatible version of our own fork of Shoelace, Synergy. It works pretty well, but we stumbled upon two issues, preventing it to work in Angular SSR environments:

1. The `<sl-alert>` component does automatically create the toast stack when imported, leading to errors in SSR environments because `document.createElement` is always fired.
2. The `scrollend-polyfill` directly checks for `'scrollend' in window` when it is included. This prevents the use of `<sl-tab-group>` in SSR environments.

We already patched this in [our alert](https://github.com/synergy-design-system/synergy-design-system/pull/764) and [polyfill](https://github.com/synergy-design-system/synergy-design-system/pull/765) implementation, but wanted to mirror this back for everyone that might be interested.

That said, as we have not tested SSR in Vanilla environments, but only in framework based ones (e.g. https://github.com/synergy-design-system/ssr-demos/tree/main/packages/angular gives a good demo with our findings).

The changes are really simple ones and, for `<sl-alert>`, also have the benefit that the stack is only created when the `toast` method is called at all.

Hope this may prove helpful for the community, also regarding the discussion in https://github.com/shoelace-style/shoelace/discussions/1641.

We would also loved to have provided this for Webawesome, but as I see, you seem to have completely got rid of `<sl-alert>` in favor of `<wa-callout>` which comes without the original toast stack functionality. Just out of curiosity, what where the reasons for this change?

Closes #2358 