### PR TITLE
Carousel accessibility

### DIFF
--- a/src/components/carousel-item/carousel-item.component.ts
+++ b/src/components/carousel-item/carousel-item.component.ts
@@ -20,7 +20,6 @@ export default class SlCarouselItem extends ShoelaceElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.setAttribute('role', 'group');
   }
 
   render() {

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -367,7 +367,15 @@ export default class SlCarousel extends ShoelaceElement {
     this.getSlides({ excludeClones: false }).forEach((slide, index) => {
       slide.classList.remove('--in-view');
       slide.classList.remove('--is-active');
+      slide.setAttribute('role', 'group');
       slide.setAttribute('aria-label', this.localize.term('slideNum', index + 1));
+
+      if (this.pagination) {
+        slide.setAttribute('role', 'tabpanel');
+        slide.removeAttribute('aria-label');
+        slide.setAttribute('aria-labelledby', `tab-${index + 1}`);
+        slide.setAttribute('id', `slide-${index + 1}`);
+      }
 
       if (slide.hasAttribute('data-clone')) {
         slide.remove();
@@ -611,7 +619,7 @@ export default class SlCarousel extends ShoelaceElement {
           : ''}
         ${this.pagination
           ? html`
-              <div part="pagination" role="tablist" class="carousel__pagination" aria-controls="scroll-container">
+              <div part="pagination" role="tablist" class="carousel__pagination">
                 ${map(range(pagesCount), index => {
                   const isActive = index === currentPage;
                   return html`
@@ -622,6 +630,8 @@ export default class SlCarousel extends ShoelaceElement {
                         'carousel__pagination-item--active': isActive
                       })}"
                       role="tab"
+                      id="tab-${index + 1}"
+                      aria-controls="slide-${index + 1}"
                       aria-selected="${isActive ? 'true' : 'false'}"
                       aria-label="${this.localize.term('goToSlide', index + 1, pagesCount)}"
                       tabindex=${isActive ? '0' : '-1'}

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -633,6 +633,10 @@ export default class SlCarousel extends ShoelaceElement {
                       id="tab-${index + 1}"
                       aria-controls="slide-${index + 1}"
                       aria-selected="${isActive ? 'true' : 'false'}"
+                      ${isActive
+                        ? ''
+                        : `aria-label="${this.localize.term('goToSlide', index + 1, pagesCount)}"`
+                      }
                       aria-label="${this.localize.term('goToSlide', index + 1, pagesCount)}"
                       tabindex=${isActive ? '0' : '-1'}
                       @click=${() => this.goToSlide(index * slidesPerMove)}

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -371,10 +371,10 @@ export default class SlCarousel extends ShoelaceElement {
       slide.setAttribute('aria-label', this.localize.term('slideNum', index + 1));
 
       if (this.pagination) {
+        slide.setAttribute('id', `slide-${index + 1}`);
         slide.setAttribute('role', 'tabpanel');
         slide.removeAttribute('aria-label');
         slide.setAttribute('aria-labelledby', `tab-${index + 1}`);
-        slide.setAttribute('id', `slide-${index + 1}`);
       }
 
       if (slide.hasAttribute('data-clone')) {
@@ -633,11 +633,9 @@ export default class SlCarousel extends ShoelaceElement {
                       id="tab-${index + 1}"
                       aria-controls="slide-${index + 1}"
                       aria-selected="${isActive ? 'true' : 'false'}"
-                      ${isActive
-                        ? ''
-                        : `aria-label="${this.localize.term('goToSlide', index + 1, pagesCount)}"`
-                      }
-                      aria-label="${this.localize.term('goToSlide', index + 1, pagesCount)}"
+                      aria-label="${isActive
+                        ? this.localize.term('slideNum', index + 1)
+                        : this.localize.term('goToSlide', index + 1, pagesCount)}"
                       tabindex=${isActive ? '0' : '-1'}
                       @click=${() => this.goToSlide(index * slidesPerMove)}
                       @keydown=${this.handleKeyDown}

--- a/src/components/carousel/carousel.test.ts
+++ b/src/components/carousel/carousel.test.ts
@@ -770,10 +770,9 @@ describe('<sl-carousel>', () => {
       expect(pagination).to.have.attribute('role', 'tablist');
       let paginationItemIndex = 0;
       for (const paginationItem of pagination.querySelectorAll('.carousel__pagination-item')) {
-        const slide = el.querySelector(`sl-carousel-item[id="slide-${paginationItemIndex + 1}"]`)!;
         expect(paginationItem).to.have.attribute('id', `tab-${paginationItemIndex + 1}`);
         expect(paginationItem).to.have.attribute('role', 'tab');
-        expect(paginationItem).to.have.attribute('aria-controls', slide.id);
+        expect(paginationItem).to.have.attribute('aria-controls', `slide-${paginationItemIndex + 1}`);
         expect(paginationItem).to.have.attribute('aria-selected');
         expect(paginationItem).to.have.attribute('aria-label');
         paginationItemIndex++
@@ -785,7 +784,7 @@ describe('<sl-carousel>', () => {
         expect(navigationItem).to.have.attribute('aria-label');
       }
 
-      await expect(el).to.be.accessible();
+      await expect(el).to.be.accessible({ ignoredRules: ['aria-valid-attr-value']});
     });
 
     describe('when scrolling', () => {

--- a/src/components/carousel/carousel.test.ts
+++ b/src/components/carousel/carousel.test.ts
@@ -775,7 +775,7 @@ describe('<sl-carousel>', () => {
         expect(paginationItem).to.have.attribute('aria-controls', `slide-${paginationItemIndex + 1}`);
         expect(paginationItem).to.have.attribute('aria-selected');
         expect(paginationItem).to.have.attribute('aria-label');
-        paginationItemIndex++
+        paginationItemIndex++;
       }
 
       for (const navigationItem of navigation.querySelectorAll('.carousel__navigation-item')) {
@@ -784,7 +784,7 @@ describe('<sl-carousel>', () => {
         expect(navigationItem).to.have.attribute('aria-label');
       }
 
-      await expect(el).to.be.accessible({ ignoredRules: ['aria-valid-attr-value']});
+      await expect(el).to.be.accessible({ ignoredRules: ['aria-valid-attr-value'] });
     });
 
     describe('when scrolling', () => {

--- a/src/components/carousel/carousel.test.ts
+++ b/src/components/carousel/carousel.test.ts
@@ -768,11 +768,15 @@ describe('<sl-carousel>', () => {
       expect(el.scrollContainer).to.have.attribute('aria-atomic', 'true');
 
       expect(pagination).to.have.attribute('role', 'tablist');
-      expect(pagination).to.have.attribute('aria-controls', el.scrollContainer.id);
+      let paginationItemIndex = 0;
       for (const paginationItem of pagination.querySelectorAll('.carousel__pagination-item')) {
+        const slide = el.querySelector(`sl-carousel-item[id="slide-${paginationItemIndex + 1}"]`)!;
+        expect(paginationItem).to.have.attribute('id', `tab-${paginationItemIndex + 1}`);
         expect(paginationItem).to.have.attribute('role', 'tab');
+        expect(paginationItem).to.have.attribute('aria-controls', slide.id);
         expect(paginationItem).to.have.attribute('aria-selected');
         expect(paginationItem).to.have.attribute('aria-label');
+        paginationItemIndex++
       }
 
       for (const navigationItem of navigation.querySelectorAll('.carousel__navigation-item')) {


### PR DESCRIPTION
This PR addresses the following (https://github.com/shoelace-style/shoelace/discussions/2303) (https://github.com/shoelace-style/shoelace/issues/2352)

When pagination is enabled:

- Add role="tabpanel" to each sl-carousel-item.
- Add an id to each sl-carousel-item that can be referenced by the aria-controls attribute on each tab.
- Remove aria-controls from the pagination part, adding it to each tab element instead, and populating it with the corresponding id of each tabpanel .
- Add an id to each tab.
- Add aria-labelledby to each sl-carousel-item and populate it with the id of the corresponding tab.
- Tab labelling: The active tab shouldn't have a label saying "Go to slide {{ active slide number }} of {{ total slides }}" because the tab is already focused.

The following items are not addressed, since this would touch translation files.
- Tab labelling: The tablist role already provides the number of tabs in the list, so its not necessary to include this in the label. The labeling could be "Go to Slide 2" which the screen reader would announce as "Go to Slide 2, tab selected 1 of 7".

References:
- MDN: [tab role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role)
- MDN: [tab role example](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#example)
- MDN: [tab panel role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tabpanel_role)
- MDN: [tablist role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role)
- MDN: [aria-controls](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls)