### PR TITLE
Fix: Nested tab groups broken in v2.19.1

### DIFF
--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -14,7 +14,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 
 ## next
 
-- Fixed a bug that prevented `<sl-tab-group>` to be activated properly when rendered in another `<sl-tab-group>` (#NR)
+- Fixed a bug that prevented `<sl-tab-group>` to be activated properly when rendered in another `<sl-tab-group>` (#2367)
 
 ## 2.20.0
 

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -12,6 +12,10 @@ Components with the <sl-badge variant="warning" pill>Experimental</sl-badge> bad
 
 New versions of Shoelace are released as-needed and generally occur when a critical mass of changes have accumulated. At any time, you can see what's coming in the next release by visiting [next.shoelace.style](https://next.shoelace.style).
 
+## next
+
+- Fixed a bug that prevented `<sl-tab-group>` to be activated properly when rendered in another `<sl-tab-group>` (#NR)
+
 ## 2.20.0
 
 - Added the ability to set a custom snap function and use `repeat(n)` to `<sl-split-panel>` [#2340]

--- a/src/components/tab-group/tab-group.component.ts
+++ b/src/components/tab-group/tab-group.component.ts
@@ -136,7 +136,7 @@ export default class SlTabGroup extends ShoelaceElement {
 
       this.mutationObserver.observe(this, {
         attributes: true,
-        attributeFilter: ['active', 'aria-labelledby', 'aria-controls', 'disabled'],
+        attributeFilter: ['active', 'disabled', 'name', 'panel'],
         childList: true,
         subtree: true
       });

--- a/src/components/tab-group/tab-group.component.ts
+++ b/src/components/tab-group/tab-group.component.ts
@@ -93,17 +93,33 @@ export default class SlTabGroup extends ShoelaceElement {
     });
 
     this.mutationObserver = new MutationObserver(mutations => {
+      // Make sure to only observe the direct children of the tab group
+      // instead of other sub elements that might be slotted in.
+      // @see https://github.com/shoelace-style/shoelace/issues/2320
+      const instanceMutations = mutations.filter(({ target }) => {
+        if (target === this) return true; // Allow self updates
+        if ((target as HTMLElement).closest('sl-tab-group') !== this) return false; // We are not direct children
+
+        // We should only care about changes to the tab or tab panel
+        const tagName = (target as HTMLElement).tagName.toLowerCase();
+        return tagName === 'sl-tab' || tagName === 'sl-tab-panel';
+      });
+
+      if (instanceMutations.length === 0) {
+        return;
+      }
+
       // Update aria labels when the DOM changes
-      if (mutations.some(m => !['aria-labelledby', 'aria-controls'].includes(m.attributeName!))) {
+      if (instanceMutations.some(m => !['aria-labelledby', 'aria-controls'].includes(m.attributeName!))) {
         setTimeout(() => this.setAriaLabels());
       }
 
       // Sync tabs when disabled states change
-      if (mutations.some(m => m.attributeName === 'disabled')) {
+      if (instanceMutations.some(m => m.attributeName === 'disabled')) {
         this.syncTabsAndPanels();
         // sync tabs when active state on tab changes
-      } else if (mutations.some(m => m.attributeName === 'active')) {
-        const tabs = mutations
+      } else if (instanceMutations.some(m => m.attributeName === 'active')) {
+        const tabs = instanceMutations
           .filter(m => m.attributeName === 'active' && (m.target as HTMLElement).tagName.toLowerCase() === 'sl-tab')
           .map(m => m.target as SlTab);
         const newActiveTab = tabs.find(tab => tab.active);
@@ -117,7 +133,14 @@ export default class SlTabGroup extends ShoelaceElement {
     // After the first update...
     this.updateComplete.then(() => {
       this.syncTabsAndPanels();
-      this.mutationObserver.observe(this, { attributes: true, childList: true, subtree: true });
+
+      this.mutationObserver.observe(this, {
+        attributes: true,
+        attributeFilter: ['active', 'aria-labelledby', 'aria-controls', 'disabled'],
+        childList: true,
+        subtree: true
+      });
+
       this.resizeObserver.observe(this.nav);
 
       // Wait for tabs and tab panels to be registered


### PR DESCRIPTION
This PR fixes #2320 by getting rid of the problems introduced by the Synergy Team with the fix https://github.com/shoelace-style/shoelace/pull/2299.

The problem was that the mutation observer was never scoped in the first place, using subtree checks to adjust itself even when children updated properties that both tabs and the children share.

This original Problem went unnoticed: [The mutation observer originally checked its subtree completely, too](https://github.com/shoelace-style/shoelace/blob/next/src/components/tab-group/tab-group.component.ts#L120).

This leads to the following errors:

- When updating an aria label in a slotted component, the mutation observer would run and update the tabs aria labels. As this is behind the scene, no one ever noticed it.
- When updating **any slotted component** that have a `disabled` or `active` prop, it will also fire the mutation observers logic.

The error became more apparent when we tried to fix the `active` property, because naturally, it is shared in both instances of `SlTabGroup`, making the navigation change of the children group cause a mutation update on the parent :(.

With this PR, I tried to:

a) Make sure to hold the original logic for the mutation observer
b) Scope the changes to the first level of mutations by not directly querying the original mutations anymore.
c) Restrict the amount of events for children attribute changes by filtering those we are interested in to make it a little more performant.

On a sidenode, I have not fully understood why we are using a `subtree` check at here at all, but there may be reasons it can be beneficial (e.g. when you have some DOM nodes wrapping the tabs or tab-groups), so I did opt to not change this, too.

