### PR TITLE
fix type exports for cherry-picked imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -111,6 +111,13 @@ module.exports = {
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unused-expressions': 'off'
       }
+    },
+    {
+      files: ['test/**/*.ts'],
+      parserOptions: {
+        project: ['tsconfig.json'],
+        tsconfigRootDir: `${__dirname}/test`
+      }
     }
   ],
   rules: {

--- a/package.json
+++ b/package.json
@@ -16,18 +16,54 @@
       "import": "./dist/shoelace.js"
     },
     "./dist/custom-elements.json": "./dist/custom-elements.json",
-    "./dist/shoelace.js": "./dist/shoelace.js",
-    "./dist/shoelace-autoloader.js": "./dist/shoelace-autoloader.js",
-    "./dist/themes": "./dist/themes",
-    "./dist/themes/*": "./dist/themes/*",
-    "./dist/components": "./dist/components",
-    "./dist/components/*": "./dist/components/*",
-    "./dist/utilities": "./dist/utilities",
-    "./dist/utilities/*": "./dist/utilities/*",
-    "./dist/react": "./dist/react/index.js",
-    "./dist/react/*": "./dist/react/*",
-    "./dist/translations": "./dist/translations",
-    "./dist/translations/*": "./dist/translations/*"
+    "./dist/shoelace.js": {
+      "types": "./dist/shoelace.d.ts",
+      "import": "./dist/shoelace.js"
+    },
+    "./dist/shoelace-autoloader.js": {
+      "types": "./dist/shoelace-autoloader.d.ts",
+      "import": "./dist/shoelace-autoloader.js"
+    },
+    "./dist/themes": {
+      "types": "./dist/themes.d.ts",
+      "import": "./dist/themes.js"
+    },
+    "./dist/themes/*": {
+      "types": "./dist/themes/*.d.ts",
+      "import": "./dist/themes/*.js"
+    },
+    "./dist/components": {
+      "types": "./dist/components.d.ts",
+      "import": "./dist/components.js"
+    },
+    "./dist/components/*": {
+      "types": "./dist/components/*.d.ts",
+      "import": "./dist/components/*.js"
+    },
+    "./dist/utilities": {
+      "types": "./dist/utilities.d.ts",
+      "import": "./dist/utilities.js"
+    },
+    "./dist/utilities/*": {
+      "types": "./dist/utilities/*.d.ts",
+      "import": "./dist/utilities/*.js"
+    },
+    "./dist/react": {
+      "types": "./dist/react/index.d.ts",
+      "import": "./dist/react/index.js"
+    },
+    "./dist/react/*": {
+      "types": "./dist/react/*/index.d.ts",
+      "import": "./dist/react/*/index.js"
+    },
+    "./dist/translations": {
+      "types": "./dist/translations.d.ts",
+      "import": "./dist/translations.js"
+    },
+    "./dist/translations/*": {
+      "types": "./dist/translations/*.d.ts",
+      "import": "./dist/translations/*.js"
+    }
   },
   "files": [
     "dist",
@@ -52,7 +88,7 @@
   "scripts": {
     "start": "node scripts/build.js --serve",
     "build": "node scripts/build.js",
-    "verify": "npm run prettier:check && npm run lint && npm run build && npm run test",
+    "verify": "npm run prettier:check && npm run lint && npm run build && npm run typecheck:dist && npm run test",
     "prepare": "npx playwright install",
     "prepublishOnly": "npm run verify",
     "prettier": "prettier --write --log-level=warn .",
@@ -63,6 +99,7 @@
     "test": "web-test-runner --group default",
     "test:component": "web-test-runner -- --watch --group",
     "test:watch": "web-test-runner --watch --group default",
+    "typecheck:dist": "tsc --noEmit --project test/tsconfig.json",
     "spellcheck": "cspell \"**/*.{js,ts,json,html,css,md}\" --no-progress",
     "check-updates": "npx npm-check-updates --interactive --format group"
   },

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,5 @@
+This directory contains only high-level smoke tests of the public API, using
+the compiled output in `dist/`.
+
+Tests in this directory should only use public, documented APIs and imports.
+Fine-grained unit tests are in `src/`.

--- a/test/react-cherry-picked-import.test.ts
+++ b/test/react-cherry-picked-import.test.ts
@@ -1,0 +1,17 @@
+import { expect } from '@open-wc/testing';
+
+/**
+ * This file tests that Node and TypeScript are able to resolve the
+ * cherry-picked import style for React components.
+ */
+import SlAnimatedImage from '@shoelace-style/shoelace/dist/react/animated-image';
+import SlAvatar from '@shoelace-style/shoelace/dist/react/avatar';
+import SlIcon from '@shoelace-style/shoelace/dist/react/icon';
+import SlSelect from '@shoelace-style/shoelace/dist/react/select';
+
+it('Should export cherry-pick-able React wrappers of the components', () => {
+  expect(SlAvatar).not.to.be.undefined;
+  expect(SlAnimatedImage).not.to.be.undefined;
+  expect(SlIcon).not.to.be.undefined;
+  expect(SlSelect).not.to.be.undefined;
+});

--- a/test/react-index-export.test.ts
+++ b/test/react-index-export.test.ts
@@ -1,0 +1,16 @@
+import { expect } from '@open-wc/testing';
+
+/**
+ * This file exists to test that Node and TypeScript are able to resolve the
+ * legacy single-index import pattern for React components.
+ */
+import { SlAlert, SlAnimation, SlButton, SlOption } from '@shoelace-style/shoelace/dist/react';
+
+// This test exists to ensure that the package exports React wrappers in a
+// manner consistent with the documentation.
+it('Should export a single module of all React components', () => {
+  expect(SlAlert).not.to.be.undefined;
+  expect(SlAnimation).not.to.be.undefined;
+  expect(SlButton).not.to.be.undefined;
+  expect(SlOption).not.to.be.undefined;
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,9 @@
+/* This tsconfig.json is used to check the compiled files in dist/ */
+{
+  "extends": "../tsconfig",
+
+  /* These paths are relative to this file, but must be within the extended
+     tsconfig's rootDir */
+  "include": ["../dist", "../test"],
+  "exclude": []
+}


### PR DESCRIPTION
Previously, the type exports worked for imports that rely on tree-shaking:

```ts
import { SlOption } from '@shoelace-style/shoelace/dist/react';
````

but not for cherry-picked imports:

```ts
import SlOption from '@shoelace-style/shoelace/dist/react/option';
```

This fixes that by declaring the type type exports for all paths.

See https://github.com/shoelace-style/shoelace/discussions/2111

**NOTE** the build is set up in such a way that there are some inconsistencies:

* For `themes/`, `utilities/`, and `translations/`, the import is of the form `@shoelace-style/shoelace/translations/ar`
* For `components/`, the import is of the form `@shoelace-style/shoelace/components/alert/alert`
* For `react/`, the import is of the form `@shoelace-style/shoelace/react/select` and references `./dist/react/select/index.js`

There aren't any tests for the React wrappers. I think if there were **and if they imported from the public paths, not relative ones**, they would have caught this.

Some alternate approaches we could use instead:

* move all the React component files out of the subdirectories so they compile to `dist/react/COMPONENT.{js,d.ts}`
* change the docs to say to import from `'@shoelace-style/shoelace/dist/react/COMPONENT/index'`