### PR TITLE
Fixes closable sl-alert can be closed on whole vertical area without visual indication

### DIFF
--- a/src/components/alert/alert.styles.ts
+++ b/src/components/alert/alert.styles.ts
@@ -94,7 +94,8 @@ export default css`
     display: flex;
     align-items: center;
     font-size: var(--sl-font-size-medium);
-    padding-inline-end: var(--sl-spacing-medium);
+    margin-inline-end: var(--sl-spacing-medium);
+    align-self: center;
   }
 
   .alert__countdown {

--- a/src/components/alert/alert.test.ts
+++ b/src/components/alert/alert.test.ts
@@ -123,20 +123,82 @@ describe('<sl-alert>', () => {
   });
 
   describe('close button', () => {
-    it('shows a close button if the alert has the closable attribute', () => async () => {
+    it('shows a close button if the alert has the closable attribute', async () => {
       const alert = await fixture<SlAlert>(html` <sl-alert open closable>I am an alert</sl-alert> `);
       const closeButton = getCloseButton(alert);
 
       expect(closeButton).to.be.visible;
     });
 
-    it('clicking the close button closes the alert', () => async () => {
+    it('clicking the close button closes the alert', async () => {
       const alert = await fixture<SlAlert>(html` <sl-alert open closable>I am an alert</sl-alert> `);
       const closeButton = getCloseButton(alert);
 
       await expectHideAndAfterHideToBeEmittedInCorrectOrder(alert, () => {
         clickOnElement(closeButton!);
       });
+    });
+
+    it('clicking above close button does not close the alert', async () => {
+      const wrapper = await fixture<HTMLDivElement>(html`<div class="wrapper" style="padding: 24px; background-color:red;"><sl-alert open closable>I am an alert</sl-alert></div>`);
+      const alert = wrapper.querySelector('sl-alert')!;
+
+      const clickTargetPromise = new Promise<HTMLElement>((resolve) => {
+        const clickHandler = sinon.spy((event: MouseEvent) => {
+          resolve(event.target as HTMLElement);
+        });
+        alert.shadowRoot!.addEventListener('click', clickHandler);
+        wrapper.addEventListener('click', clickHandler);
+      });
+
+      const closeButton = getCloseButton(alert);
+      await clickOnElement(closeButton!, 'top', 0, -4);
+      const clickTarget = await clickTargetPromise;
+      await expect(clickTarget.tagName.toLowerCase()).to.not.be.equal('sl-icon-button');
+      expect(clickTarget.classList.contains('alert')).to.be.true;
+      expect(clickTarget.classList.contains('wrapper'), 'The click should happen in the alert and not outside of it').to.be.false;
+    });
+
+    it('clicking under close button does not close the alert', async () => {
+      const wrapper = await fixture<HTMLDivElement>(html`<div class="wrapper" style="padding: 24px; background-color:red;"><sl-alert open closable>I am an alert</sl-alert></div>`);
+      const alert = wrapper.querySelector('sl-alert')!;
+
+      const clickTargetPromise = new Promise<HTMLElement>((resolve) => {
+        const clickHandler = sinon.spy((event: MouseEvent) => {
+          resolve(event.target as HTMLElement);
+        });
+        alert.shadowRoot!.addEventListener('click', clickHandler);
+        wrapper.addEventListener('click', clickHandler);
+      });
+
+      const closeButton = getCloseButton(alert);
+      await clickOnElement(closeButton!, 'bottom', 0, 4);
+      const clickTarget = await clickTargetPromise;
+
+      await expect(clickTarget.tagName.toLowerCase()).to.not.be.equal('sl-icon-button');
+      expect(clickTarget.classList.contains('alert')).to.be.true;
+      expect(clickTarget.classList.contains('wrapper'), 'The click should happen in the alert and not outside of it').to.be.false;
+    });
+
+    it('clicking on the right side of the close button does not close the alert', async () => {
+      const wrapper = await fixture<HTMLDivElement>(html`<div class="wrapper" style="padding: 24px; background-color:red;"><sl-alert open closable>I am an alert</sl-alert></div>`);
+      const alert = wrapper.querySelector('sl-alert')!;
+
+      const clickTargetPromise = new Promise<HTMLElement>((resolve) => {
+        const clickHandler = sinon.spy((event: MouseEvent) => {
+          resolve(event.target as HTMLElement);
+        });
+        alert.shadowRoot!.addEventListener('click', clickHandler);
+        wrapper.addEventListener('click', clickHandler);
+      });
+
+      const closeButton = getCloseButton(alert);
+      await clickOnElement(closeButton!, 'right', 4, 0);
+      const clickTarget = await clickTargetPromise;
+
+      await expect(clickTarget.tagName.toLowerCase()).to.not.be.equal('sl-icon-button');
+      expect(clickTarget.classList.contains('alert')).to.be.true;
+      expect(clickTarget.classList.contains('wrapper'), 'The click should happen in the alert and not outside of it').to.be.false;
     });
   });
 

--- a/src/components/alert/alert.test.ts
+++ b/src/components/alert/alert.test.ts
@@ -140,10 +140,14 @@ describe('<sl-alert>', () => {
     });
 
     it('clicking above close button does not close the alert', async () => {
-      const wrapper = await fixture<HTMLDivElement>(html`<div class="wrapper" style="padding: 24px; background-color:red;"><sl-alert open closable>I am an alert</sl-alert></div>`);
+      const wrapper = await fixture<HTMLDivElement>(
+        html`<div class="wrapper" style="padding: 24px; background-color:red;">
+          <sl-alert open closable>I am an alert</sl-alert>
+        </div>`
+      );
       const alert = wrapper.querySelector('sl-alert')!;
 
-      const clickTargetPromise = new Promise<HTMLElement>((resolve) => {
+      const clickTargetPromise = new Promise<HTMLElement>(resolve => {
         const clickHandler = sinon.spy((event: MouseEvent) => {
           resolve(event.target as HTMLElement);
         });
@@ -156,14 +160,19 @@ describe('<sl-alert>', () => {
       const clickTarget = await clickTargetPromise;
       await expect(clickTarget.tagName.toLowerCase()).to.not.be.equal('sl-icon-button');
       expect(clickTarget.classList.contains('alert')).to.be.true;
-      expect(clickTarget.classList.contains('wrapper'), 'The click should happen in the alert and not outside of it').to.be.false;
+      expect(clickTarget.classList.contains('wrapper'), 'The click should happen in the alert and not outside of it').to
+        .be.false;
     });
 
     it('clicking under close button does not close the alert', async () => {
-      const wrapper = await fixture<HTMLDivElement>(html`<div class="wrapper" style="padding: 24px; background-color:red;"><sl-alert open closable>I am an alert</sl-alert></div>`);
+      const wrapper = await fixture<HTMLDivElement>(
+        html`<div class="wrapper" style="padding: 24px; background-color:red;">
+          <sl-alert open closable>I am an alert</sl-alert>
+        </div>`
+      );
       const alert = wrapper.querySelector('sl-alert')!;
 
-      const clickTargetPromise = new Promise<HTMLElement>((resolve) => {
+      const clickTargetPromise = new Promise<HTMLElement>(resolve => {
         const clickHandler = sinon.spy((event: MouseEvent) => {
           resolve(event.target as HTMLElement);
         });
@@ -177,14 +186,19 @@ describe('<sl-alert>', () => {
 
       await expect(clickTarget.tagName.toLowerCase()).to.not.be.equal('sl-icon-button');
       expect(clickTarget.classList.contains('alert')).to.be.true;
-      expect(clickTarget.classList.contains('wrapper'), 'The click should happen in the alert and not outside of it').to.be.false;
+      expect(clickTarget.classList.contains('wrapper'), 'The click should happen in the alert and not outside of it').to
+        .be.false;
     });
 
     it('clicking on the right side of the close button does not close the alert', async () => {
-      const wrapper = await fixture<HTMLDivElement>(html`<div class="wrapper" style="padding: 24px; background-color:red;"><sl-alert open closable>I am an alert</sl-alert></div>`);
+      const wrapper = await fixture<HTMLDivElement>(
+        html`<div class="wrapper" style="padding: 24px; background-color:red;">
+          <sl-alert open closable>I am an alert</sl-alert>
+        </div>`
+      );
       const alert = wrapper.querySelector('sl-alert')!;
 
-      const clickTargetPromise = new Promise<HTMLElement>((resolve) => {
+      const clickTargetPromise = new Promise<HTMLElement>(resolve => {
         const clickHandler = sinon.spy((event: MouseEvent) => {
           resolve(event.target as HTMLElement);
         });
@@ -198,7 +212,8 @@ describe('<sl-alert>', () => {
 
       await expect(clickTarget.tagName.toLowerCase()).to.not.be.equal('sl-icon-button');
       expect(clickTarget.classList.contains('alert')).to.be.true;
-      expect(clickTarget.classList.contains('wrapper'), 'The click should happen in the alert and not outside of it').to.be.false;
+      expect(clickTarget.classList.contains('wrapper'), 'The click should happen in the alert and not outside of it').to
+        .be.false;
     });
   });
 

--- a/src/internal/test.ts
+++ b/src/internal/test.ts
@@ -47,7 +47,7 @@ export async function clickOnElement(
 ) {
   const { clickX, clickY } = determineMousePosition(el, position, offsetX, offsetY);
 
-  await sendMouse({ type: 'click', position: [clickX, clickY] });
+  await sendMouse({ type: 'click', position: [Math.round(clickX), Math.round(clickY)] });
 }
 
 /** A testing utility that moves the mouse onto an element. */


### PR DESCRIPTION
This PR fixes the issue, that the area above, under and on the right side of the closable icon button of the alert, also closes the alert without visual indication. 
This PR avoids the strechting of the close icon and uses margin instead of padding for the close icon, as otherwise the padding is used as part of the close icon.

Closes #2374 