### PR TITLE
Fix a11y issues for closing components with focused children

### DIFF
--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -12,6 +12,10 @@ Components with the <sl-badge variant="warning" pill>Experimental</sl-badge> bad
 
 New versions of Shoelace are released as-needed and generally occur when a critical mass of changes have accumulated. At any time, you can see what's coming in the next release by visiting [next.shoelace.style](https://next.shoelace.style).
 
+## Next
+
+- Fixed accessibility issues for elements that are closed while having slotted focused children.
+
 ## 2.20.0
 
 - Added the ability to set a custom snap function and use `repeat(n)` to `<sl-split-panel>` [#2340]

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -14,7 +14,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 
 ## Next
 
-- Fixed accessibility issues for elements that are closed while having slotted focused children.
+- Fixed accessibility issues for elements that are closed while having slotted focused children. [#2383]
 
 ## 2.20.0
 

--- a/src/components/alert/alert.component.ts
+++ b/src/components/alert/alert.component.ts
@@ -1,4 +1,5 @@
 import { animateTo, stopAnimations } from '../../internal/animate.js';
+import { blurActiveElement } from '../../internal/closeActiveElement.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { getAnimation, setDefaultAnimation } from '../../utilities/animation-registry.js';
 import { HasSlotController } from '../../internal/slot.js';
@@ -157,6 +158,7 @@ export default class SlAlert extends ShoelaceElement {
       this.emit('sl-after-show');
     } else {
       // Hide
+      blurActiveElement(this);
       this.emit('sl-hide');
 
       clearTimeout(this.autoHideTimeout);

--- a/src/components/dialog/dialog.component.ts
+++ b/src/components/dialog/dialog.component.ts
@@ -1,4 +1,5 @@
 import { animateTo, stopAnimations } from '../../internal/animate.js';
+import { blurActiveElement } from '../../internal/closeActiveElement.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { getAnimation, setDefaultAnimation } from '../../utilities/animation-registry.js';
 import { HasSlotController } from '../../internal/slot.js';
@@ -208,6 +209,7 @@ export default class SlDialog extends ShoelaceElement {
       this.emit('sl-after-show');
     } else {
       // Hide
+      blurActiveElement(this);
       this.emit('sl-hide');
       this.removeOpenListeners();
       this.modal.deactivate();

--- a/src/components/drawer/drawer.component.ts
+++ b/src/components/drawer/drawer.component.ts
@@ -1,4 +1,5 @@
 import { animateTo, stopAnimations } from '../../internal/animate.js';
+import { blurActiveElement } from '../../internal/closeActiveElement.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { getAnimation, setDefaultAnimation } from '../../utilities/animation-registry.js';
 import { HasSlotController } from '../../internal/slot.js';
@@ -237,6 +238,7 @@ export default class SlDrawer extends ShoelaceElement {
       this.emit('sl-after-show');
     } else {
       // Hide
+      blurActiveElement(this);
       this.emit('sl-hide');
       this.removeOpenListeners();
 

--- a/src/internal/closeActiveElement.ts
+++ b/src/internal/closeActiveElement.ts
@@ -6,7 +6,6 @@
  */
 export const blurActiveElement = (elm: HTMLElement) => {
   const { activeElement } = document;
-  console.log(activeElement, elm);
   if (activeElement && elm.contains(activeElement)) {
     (document.activeElement as HTMLElement)?.blur();
   }

--- a/src/internal/closeActiveElement.ts
+++ b/src/internal/closeActiveElement.ts
@@ -1,0 +1,13 @@
+/**
+ * Calls the blur method on the current active element if it is a child of the provided element.
+ * Needed for fixing a11y errors in console.
+ * @see https://github.com/shoelace-style/shoelace/issues/2283
+ * @param elm The element to check
+ */
+export const blurActiveElement = (elm: HTMLElement) => {
+  const { activeElement } = document;
+  console.log(activeElement, elm);
+  if (activeElement && elm.contains(activeElement)) {
+    (document.activeElement as HTMLElement)?.blur();
+  }
+};


### PR DESCRIPTION
Hey Shoelace team,

as other people have pointed out, there are some issues with closable components when they have focused slotted children. We already created patches for our own Shoelace fork and I wanted to mirror those back to you in case they are helpful.

This PR adds a new utility function `blurActiveElement` that makes sure the focus for elements is removed when they become invisible.

Fixes #2335
Fixes #2283