### PR TITLE
WIP feat: make flexible custom element name couplings

### DIFF
--- a/src/components/alert/alert.component.ts
+++ b/src/components/alert/alert.component.ts
@@ -3,6 +3,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { getAnimation, setDefaultAnimation } from '../../utilities/animation-registry.js';
 import { HasSlotController } from '../../internal/slot.js';
 import { html } from 'lit';
+import { literal, html as staticHtml, unsafeStatic } from 'lit/static-html.js';
 import { LocalizeController } from '../../utilities/localize.js';
 import { property, query, state } from 'lit/decorators.js';
 import { waitForEvent } from '../../internal/event.js';
@@ -92,6 +93,13 @@ export default class SlAlert extends ShoelaceElement {
 
   firstUpdated() {
     this.base.hidden = !this.open;
+  }
+
+  protected get internalTagNames() {
+    return {
+      iconButton: `sl-icon-button`,
+      self: 'sl-alert'
+    };
   }
 
   private restartAutoHide() {
@@ -224,7 +232,7 @@ export default class SlAlert extends ShoelaceElement {
           resolve();
 
           // Remove the toast stack from the DOM when there are no more alerts
-          if (SlAlert.toastStack.querySelector('sl-alert') === null) {
+          if (SlAlert.toastStack.querySelector(this.internalTagNames.self) === null) {
             SlAlert.toastStack.remove();
           }
         },
@@ -263,8 +271,8 @@ export default class SlAlert extends ShoelaceElement {
         </div>
 
         ${this.closable
-          ? html`
-              <sl-icon-button
+          ? staticHtml`
+              <${literal`${unsafeStatic(this.internalTagNames.iconButton)}`}
                 part="close-button"
                 exportparts="base:close-button__base"
                 class="alert__close-button"
@@ -272,7 +280,7 @@ export default class SlAlert extends ShoelaceElement {
                 library="system"
                 label=${this.localize.term('close')}
                 @click=${this.handleCloseClick}
-              ></sl-icon-button>
+              ></${literal`${unsafeStatic(this.internalTagNames.iconButton)}`}>
             `
           : ''}
 

--- a/src/components/animated-image/animated-image.component.ts
+++ b/src/components/animated-image/animated-image.component.ts
@@ -1,4 +1,5 @@
 import { html } from 'lit';
+import { literal, html as staticHtml, unsafeStatic } from 'lit/static-html.js';
 import { property, query, state } from 'lit/decorators.js';
 import { watch } from '../../internal/watch.js';
 import componentStyles from '../../styles/component.styles.js';
@@ -43,6 +44,12 @@ export default class SlAnimatedImage extends ShoelaceElement {
 
   /** Plays the animation. When this attribute is remove, the animation will pause. */
   @property({ type: Boolean, reflect: true }) play: boolean;
+
+  protected get internalTagNames() {
+    return {
+      icon: 'sl-icon'
+    };
+  }
 
   private handleClick() {
     this.play = !this.play;
@@ -106,8 +113,18 @@ export default class SlAnimatedImage extends ShoelaceElement {
               />
 
               <div part="control-box" class="animated-image__control-box">
-                <slot name="play-icon"><sl-icon name="play-fill" library="system"></sl-icon></slot>
-                <slot name="pause-icon"><sl-icon name="pause-fill" library="system"></sl-icon></slot>
+                <slot name="play-icon"
+                  >${staticHtml`<${literal`${unsafeStatic(this.internalTagNames.icon)}`} 
+                    name="play-fill" 
+                    library="system"
+                  ></${literal`${unsafeStatic(this.internalTagNames.icon)}`}>`}</slot
+                >
+                <slot name="pause-icon"
+                  >${staticHtml`<${literal`${unsafeStatic(this.internalTagNames.icon)}`}
+                    name="pause-fill"
+                    library="system"
+                  ></${literal`${unsafeStatic(this.internalTagNames.icon)}`}>`}</slot
+                >
               </div>
             `
           : ''}

--- a/src/components/animation/animation.component.ts
+++ b/src/components/animation/animation.component.ts
@@ -28,7 +28,9 @@ export default class SlAnimation extends ShoelaceElement {
 
   @queryAsync('slot') defaultSlot: Promise<HTMLSlotElement>;
 
-  /** The name of the built-in animation to use. For custom animations, use the `keyframes` prop. */
+  /**
+   * The name of the built-in animation to use. For custom animations, use the `keyframes` prop.
+   */
   @property() name = 'none';
 
   /**

--- a/src/components/avatar/avatar.component.ts
+++ b/src/components/avatar/avatar.component.ts
@@ -1,5 +1,6 @@
 import { classMap } from 'lit/directives/class-map.js';
 import { html } from 'lit';
+import { literal, html as staticHtml, unsafeStatic } from 'lit/static-html.js';
 import { property, state } from 'lit/decorators.js';
 import { watch } from '../../internal/watch.js';
 import componentStyles from '../../styles/component.styles.js';
@@ -57,6 +58,12 @@ export default class SlAvatar extends ShoelaceElement {
     this.hasError = false;
   }
 
+  protected get internalTagNames() {
+    return {
+      icon: 'sl-icon'
+    };
+  }
+
   private handleImageLoadError() {
     this.hasError = true;
     this.emit('sl-error');
@@ -82,7 +89,10 @@ export default class SlAvatar extends ShoelaceElement {
       avatarWithoutImage = html`
         <div part="icon" class="avatar__icon" aria-hidden="true">
           <slot name="icon">
-            <sl-icon name="person-fill" library="system"></sl-icon>
+            ${staticHtml`<${literal`${unsafeStatic(this.internalTagNames.icon)}`} 
+              name="person-fill" 
+              library="system"
+            ></${literal`${unsafeStatic(this.internalTagNames.icon)}`}>`}
           </slot>
         </div>
       `;

--- a/src/components/breadcrumb-item/breadcrumb-item.component.ts
+++ b/src/components/breadcrumb-item/breadcrumb-item.component.ts
@@ -48,10 +48,17 @@ export default class SlBreadcrumbItem extends ShoelaceElement {
   /** The `rel` attribute to use on the link. Only used when `href` is set. */
   @property() rel = 'noreferrer noopener';
 
+  protected get internalTagNames() {
+    return {
+      dropdown: 'sl-dropdown'
+    };
+  }
+
   private setRenderType() {
     const hasDropdown =
-      this.defaultSlot.assignedElements({ flatten: true }).filter(i => i.tagName.toLowerCase() === 'sl-dropdown')
-        .length > 0;
+      this.defaultSlot
+        .assignedElements({ flatten: true })
+        .filter(i => i.tagName.toLowerCase() === this.internalTagNames.dropdown).length > 0;
 
     if (this.href) {
       this.renderType = 'link';

--- a/src/components/breadcrumb/breadcrumb.component.ts
+++ b/src/components/breadcrumb/breadcrumb.component.ts
@@ -1,4 +1,5 @@
 import { html } from 'lit';
+import { literal, html as staticHtml, unsafeStatic } from 'lit/static-html.js';
 import { LocalizeController } from '../../utilities/localize.js';
 import { property, query } from 'lit/decorators.js';
 import componentStyles from '../../styles/component.styles.js';
@@ -37,6 +38,13 @@ export default class SlBreadcrumb extends ShoelaceElement {
    */
   @property() label = '';
 
+  protected get internalTagNames() {
+    return {
+      icon: 'sl-icon',
+      breadcrumbItem: 'sl-breadcrumb-item'
+    };
+  }
+
   // Generates a clone of the separator element to use for each breadcrumb item
   private getSeparator() {
     const separator = this.separatorSlot.assignedElements({ flatten: true })[0] as HTMLElement;
@@ -52,7 +60,7 @@ export default class SlBreadcrumb extends ShoelaceElement {
 
   private handleSlotChange() {
     const items = [...this.defaultSlot.assignedElements({ flatten: true })].filter(
-      item => item.tagName.toLowerCase() === 'sl-breadcrumb-item'
+      item => item.tagName.toLowerCase() === this.internalTagNames.breadcrumbItem
     ) as SlBreadcrumbItem[];
 
     items.forEach((item, index) => {
@@ -93,7 +101,10 @@ export default class SlBreadcrumb extends ShoelaceElement {
 
       <span hidden aria-hidden="true">
         <slot name="separator">
-          <sl-icon name=${this.localize.dir() === 'rtl' ? 'chevron-left' : 'chevron-right'} library="system"></sl-icon>
+          ${staticHtml`<${literal`${unsafeStatic(this.internalTagNames.icon)}`} 
+            name=${this.localize.dir() === 'rtl' ? 'chevron-left' : 'chevron-right'} 
+            library="system"
+          ></${literal`${unsafeStatic(this.internalTagNames.icon)}`}>`}
         </slot>
       </span>
     `;

--- a/src/components/button-group/button-group.component.ts
+++ b/src/components/button-group/button-group.component.ts
@@ -28,23 +28,30 @@ export default class SlButtonGroup extends ShoelaceElement {
    */
   @property() label = '';
 
+  protected get internalTagNames() {
+    return {
+      button: 'sl-button',
+      radioButton: 'sl-radio-button'
+    };
+  }
+
   private handleFocus(event: Event) {
-    const button = findButton(event.target as HTMLElement);
+    const button = this.findButton(event.target as HTMLElement);
     button?.toggleAttribute('data-sl-button-group__button--focus', true);
   }
 
   private handleBlur(event: Event) {
-    const button = findButton(event.target as HTMLElement);
+    const button = this.findButton(event.target as HTMLElement);
     button?.toggleAttribute('data-sl-button-group__button--focus', false);
   }
 
   private handleMouseOver(event: Event) {
-    const button = findButton(event.target as HTMLElement);
+    const button = this.findButton(event.target as HTMLElement);
     button?.toggleAttribute('data-sl-button-group__button--hover', true);
   }
 
   private handleMouseOut(event: Event) {
-    const button = findButton(event.target as HTMLElement);
+    const button = this.findButton(event.target as HTMLElement);
     button?.toggleAttribute('data-sl-button-group__button--hover', false);
   }
 
@@ -53,7 +60,7 @@ export default class SlButtonGroup extends ShoelaceElement {
 
     slottedElements.forEach(el => {
       const index = slottedElements.indexOf(el);
-      const button = findButton(el);
+      const button = this.findButton(el);
 
       if (button) {
         button.toggleAttribute('data-sl-button-group__button', true);
@@ -62,10 +69,17 @@ export default class SlButtonGroup extends ShoelaceElement {
         button.toggleAttribute('data-sl-button-group__button--last', index === slottedElements.length - 1);
         button.toggleAttribute(
           'data-sl-button-group__button--radio',
-          button.tagName.toLowerCase() === 'sl-radio-button'
+          button.tagName.toLowerCase() === this.internalTagNames.radioButton
         );
       }
     });
+  }
+
+  private findButton(el: HTMLElement) {
+    const selector = `${this.internalTagNames.button}, ${this.internalTagNames.radioButton}`;
+
+    // The button could be the target element or a child of it (e.g. a dropdown or tooltip anchor)
+    return el.closest(selector) ?? el.querySelector(selector);
   }
 
   render() {
@@ -85,11 +99,4 @@ export default class SlButtonGroup extends ShoelaceElement {
       </div>
     `;
   }
-}
-
-function findButton(el: HTMLElement) {
-  const selector = 'sl-button, sl-radio-button';
-
-  // The button could be the target element or a child of it (e.g. a dropdown or tooltip anchor)
-  return el.closest(selector) ?? el.querySelector(selector);
 }

--- a/src/components/button/button.component.ts
+++ b/src/components/button/button.component.ts
@@ -1,7 +1,7 @@
 import { classMap } from 'lit/directives/class-map.js';
 import { FormControlController, validValidityState } from '../../internal/form.js';
 import { HasSlotController } from '../../internal/slot.js';
-import { html, literal } from 'lit/static-html.js';
+import { html, literal, unsafeStatic } from 'lit/static-html.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeController } from '../../utilities/localize.js';
 import { property, query, state } from 'lit/decorators.js';
@@ -167,6 +167,13 @@ export default class SlButton extends ShoelaceElement implements ShoelaceFormCon
     }
   }
 
+  protected get internalTagNames() {
+    return {
+      icon: 'sl-icon',
+      spinner: 'sl-spinner'
+    };
+  }
+
   private handleBlur() {
     this.hasFocus = false;
     this.emit('sl-blur');
@@ -309,9 +316,25 @@ export default class SlButton extends ShoelaceElement implements ShoelaceFormCon
         <slot part="label" class="button__label"></slot>
         <slot name="suffix" part="suffix" class="button__suffix"></slot>
         ${
-          this.caret ? html` <sl-icon part="caret" class="button__caret" library="system" name="caret"></sl-icon> ` : ''
+          this.caret
+            ? html`
+                <${literal`${unsafeStatic(this.internalTagNames.icon)}`} 
+                  part="caret"
+                  class="button__caret"
+                  library="system"
+                  name="caret"
+                ></${literal`${unsafeStatic(this.internalTagNames.icon)}`}>
+              `
+            : ''
         }
-        ${this.loading ? html`<sl-spinner part="spinner"></sl-spinner>` : ''}
+        ${
+          this.loading
+            ? html`
+              <${literal`${unsafeStatic(this.internalTagNames.spinner)}`} class="button__spinner" part="spinner">
+              </${literal`${unsafeStatic(this.internalTagNames.spinner)}`}>
+            `
+            : ''
+        }
       </${tag}>
     `;
     /* eslint-enable lit/no-invalid-html */

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -66,7 +66,7 @@ export default css`
     display: inline-block;
   }
 
-  .button__label::slotted(sl-icon) {
+  .button__label::slotted(.button__caret) {
     vertical-align: -2px;
   }
 
@@ -441,7 +441,7 @@ export default css`
     visibility: hidden;
   }
 
-  .button--loading sl-spinner {
+  .button--loading .button__spinner {
     --indicator-color: currentColor;
     position: absolute;
     font-size: 1em;
@@ -455,7 +455,8 @@ export default css`
    * Badges
    */
 
-  .button ::slotted(sl-badge) {
+  .button ::slotted(sl-badge),
+  .button ::slotted(.button__badge) {
     position: absolute;
     top: 0;
     right: 0;
@@ -463,7 +464,8 @@ export default css`
     pointer-events: none;
   }
 
-  .button--rtl ::slotted(sl-badge) {
+  .button--rtl ::slotted(sl-badge),
+  .button--rtl ::slotted(.button__badge) {
     right: auto;
     left: 0;
     translate: -50% -50%;

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -5,6 +5,7 @@ import { clamp } from '../../internal/math.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { eventOptions, property, query, state } from 'lit/decorators.js';
 import { html } from 'lit';
+import { literal, html as staticHtml, unsafeStatic } from 'lit/static-html.js';
 import { LocalizeController } from '../../utilities/localize.js';
 import { map } from 'lit/directives/map.js';
 import { prefersReducedMotion } from '../../internal/animate.js';
@@ -122,6 +123,13 @@ export default class SlCarousel extends ShoelaceElement {
     if (changedProperties.has('slidesPerMove') || changedProperties.has('slidesPerPage')) {
       this.slidesPerMove = Math.min(this.slidesPerMove, this.slidesPerPage);
     }
+  }
+
+  protected get internalTagNames() {
+    return {
+      icon: 'sl-icon',
+      carouselItem: 'sl-carousel-item'
+    };
   }
 
   private getPageCount() {
@@ -342,7 +350,7 @@ export default class SlCarousel extends ShoelaceElement {
   }
 
   private isCarouselItem(node: Node): node is SlCarouselItem {
-    return node instanceof Element && node.tagName.toLowerCase() === 'sl-carousel-item';
+    return node instanceof Element && node.tagName.toLowerCase() === this.internalTagNames.carouselItem;
   }
 
   private handleSlotChange = (mutations: MutationRecord[]) => {
@@ -586,7 +594,10 @@ export default class SlCarousel extends ShoelaceElement {
                   @click=${prevEnabled ? () => this.previous() : null}
                 >
                   <slot name="previous-icon">
-                    <sl-icon library="system" name="${isLtr ? 'chevron-left' : 'chevron-right'}"></sl-icon>
+                    ${staticHtml`<${literal`${unsafeStatic(this.internalTagNames.icon)}`} 
+                      library="system"
+                      name="${isLtr ? 'chevron-left' : 'chevron-right'}"
+                    ></${literal`${unsafeStatic(this.internalTagNames.icon)}`}>`}
                   </slot>
                 </button>
 
@@ -603,7 +614,10 @@ export default class SlCarousel extends ShoelaceElement {
                   @click=${nextEnabled ? () => this.next() : null}
                 >
                   <slot name="next-icon">
-                    <sl-icon library="system" name="${isLtr ? 'chevron-right' : 'chevron-left'}"></sl-icon>
+                    ${staticHtml`<${literal`${unsafeStatic(this.internalTagNames.icon)}`} 
+                      library="system"
+                      name="${isLtr ? 'chevron-right' : 'chevron-left'}"
+                    ></${literal`${unsafeStatic(this.internalTagNames.icon)}`}>`}
                   </slot>
                 </button>
               </div>

--- a/src/components/carousel/carousel.styles.ts
+++ b/src/components/carousel/carousel.styles.ts
@@ -76,10 +76,8 @@ export default css`
     overflow-x: hidden;
   }
 
-  .carousel__slides--dragging {
-  }
-
-  :host([vertical]) ::slotted(sl-carousel-item) {
+  :host([vertical]) ::slotted(sl-carousel-item),
+  :host([vertical]) ::slotted(.carousel__item) {
     height: 100%;
   }
 


### PR DESCRIPTION
Hey @claviska 

Related discussion https://github.com/shoelace-style/shoelace/discussions/2368

I wanted to check how much work/impact it would be to make this design system flexible in terms of custom element definitions.

I just made a small start on the first couple components in the repo for two reasons:
- To make things a bit more concrete about what making Shoelace flexible in terms of CE names entails, what exactly is the impact? The discussion was still a bit vague/abstract.
- I'm going to end up doing these changes no matter what 😅 since there is a hard requirement for it on my end. So I might as well share it in an early stage and see what feedback I can gather, and maybe convince you to accept it as a contribution to Shoelace, which of course would be much better than maintaining a fork/patch.


So, getting into the changes now, there are 3 main categories of CE name couplings that I have found so far:
- CE tagnames as strings, simple, e.g. for query selecting, checking that an inner element is of a certain tagName e.g. `sl-menu-item` inside `sl-menu`
- CSS couplings -> tag selectors. When rendered internally, we can easily add or use a class name instead, I've made a few changes for this already which come at no cost. For content projection (slottables, projected by consumers) we can add a selector with a class in addition to the element selector, so that users can project custom content, attach a CSS class, and the styles will apply. If the "original" sl-element is used, no need to add a class of course, it just keeps working as is.
- Rendered custom elements, this is the tricky part, where we need to use dynamic tags using Lit's static expressions. Not ideal but for an inner element here and there, I don't think it's that bad. Again, we already do this in the button component just as an example. Use of `unsafeStatic` can also be prevented by adjusting the protected getter, and letting subclassers define both the string and the tag literal:
  ```js
  protected get internalTagNames() {
    return {
      icon: {
        // preventing the need for literal`${unsafeStatic(thing)}`.
        name: 'sl-icon', // when string value is needed
        tag: literal`sl-icon`, // when dynamic tag is needed
      }
    };
  }
  ```
  But this can be done in the next step

____

Btw, I understand the criticism towards microfrontends. Microfrontends aren't an ideal technical solution, no one will disagree with this. It's a solution to an organizational/scalability problem. Big bang migrations between major versions of design systems are not doable in very large enterprises where application/feature team autonomy is key for scalability and productivity, so regardless of all of the downsides of loading multiple design system versions and scoping custom element names, it is a widely adopted "pragmatic" solution in these kinds of environments.
Additionally, microfrontends isn't the only reason why this is important to us. We also need this in order to be able to create subclass extensions of Shoelace elements e.g. to enable us to adjust or add interaction/behaviors that go beyond styling shadow parts or theming. I think adding this flexibility to Shoelace will bolster adoption for those who need this type of flexibility/extensibility, with very little harm/negative tradeoffs that I can see.

Since I'm going to continue the work regardless, I might as well contribute it and see if I can sway you guys to adopt it. If not, then obviously that's your prerogative as the maintainer(s), I appreciate the work done on this project as open source volunteers no matter what, whether I can convince you on these contributions or not :).

Let me know your thoughts!