### PR TITLE
fix contextElement guard

### DIFF
--- a/src/components/popup/popup.component.ts
+++ b/src/components/popup/popup.component.ts
@@ -19,7 +19,7 @@ function isVirtualElement(e: unknown): e is VirtualElement {
     e !== null &&
     typeof e === 'object' &&
     'getBoundingClientRect' in e &&
-    ('contextElement' in e ? e instanceof Element : true)
+    ('contextElement' in e ? e.contextElement instanceof Element : true)
   );
 }
 


### PR DESCRIPTION
Fixed the guard on popover to allow virtual `contextElement`
I assume there was no tests because this was not working as specified in the documentation.