### PR TITLE
Fix link to Rails example repo on 'Integrating with Rails' page

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -112,7 +112,7 @@
     "Numberish",
     "onscrollend",
     "outdir",
-    "ParamagicDev",
+    "KonnorRogers",
     "peta",
     "petabit",
     "prismjs",

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -1622,7 +1622,7 @@ The component API remains the same except for the changes noted below. Thanks fo
 - Added `spellcheck` attribute to `<sl-input>`
 - Added `<sl-icon-library>` to allow custom icon library registration
 - Added `library` attribute to `<sl-icon>` and `<sl-icon-button>`
-- Added "Integrating with Rails" tutorial to the docs, courtesy of [ParamagicDev](https://github.com/ParamagicDev)
+- Added "Integrating with Rails" tutorial to the docs, courtesy of [KonnorRogers](https://github.com/KonnorRogers)
 - Fixed a bug where `<sl-progress-ring>` rendered incorrectly when zoomed in Safari [#227]
 - Fixed a bug where tabbing into slotted elements closes `<sl-dropdown>` when used in a shadow root [#223]
 - Fixed a bug where scroll anchoring caused undesirable scrolling when `<sl-details>` are grouped

--- a/docs/pages/tutorials/integrating-with-rails.md
+++ b/docs/pages/tutorials/integrating-with-rails.md
@@ -106,5 +106,5 @@ Now you can start using Shoelace components with Rails!
 
 ## Additional Resources
 
-- There is a third-party [example repo](https://github.com/ParamagicDev/rails-shoelace-example), courtesy of [ParamagicDev](https://github.com/ParamagicDev) available to help you get started.
+- There is a third-party [example repo](https://github.com/KonnorRogers/rails-shoelace-example), courtesy of [KonnorRogers](https://github.com/KonnorRogers) available to help you get started.
 - If you would like to avoid repeating this process, check out the associated [Railsbyte for Shoelace](https://railsbytes.com/templates/X8BsEb).


### PR DESCRIPTION
I noticed that the link to the Rails example repo on the ["Integrating with Rails"](https://shoelace.style/tutorials/integrating-with-rails#additional-resources) page is linking to @KonnorRogers's old handle. This pull request updates the link and also replaces all other references of his old username.