### PR TITLE
Fix issue #2414

### DIFF
--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -259,6 +259,7 @@ export default css`
     padding: 0;
     transition: var(--sl-transition-fast) color;
     cursor: pointer;
+    flex-shrink: 0;
   }
 
   .input__clear:hover,


### PR DESCRIPTION
To fix the issue with the clear button collapsing when the input has a small width, we added "flex-shrink:0" to the clear button CSS. This prevents the clear button from shrinking when the input field is small. 