### PR TITLE
Fixed invalid css property values causing warnings on Firefox

### DIFF
--- a/src/components/radio/radio.styles.ts
+++ b/src/components/radio/radio.styles.ts
@@ -11,7 +11,7 @@ export default css`
 
   .radio {
     display: inline-flex;
-    align-items: top;
+    align-items: start;
     font-family: var(--sl-input-font-family);
     font-size: var(--sl-input-font-size-medium);
     font-weight: var(--sl-input-font-weight);

--- a/src/components/radio/radio.styles.ts
+++ b/src/components/radio/radio.styles.ts
@@ -11,7 +11,7 @@ export default css`
 
   .radio {
     display: inline-flex;
-    align-items: start;
+    align-items: flex-start;
     font-family: var(--sl-input-font-family);
     font-size: var(--sl-input-font-size-medium);
     font-weight: var(--sl-input-font-weight);

--- a/src/components/select/select.styles.ts
+++ b/src/components/select/select.styles.ts
@@ -301,7 +301,7 @@ export default css`
     display: flex;
     align-items: center;
     transition: var(--sl-transition-medium) rotate ease;
-    rotate: 0;
+    rotate: 0deg;
     margin-inline-start: var(--sl-spacing-small);
   }
 


### PR DESCRIPTION
Fixed some invalid css that was harmless due to the intended value being the default anyway, but which shows warnings in the console on Firefox