### PR TITLE
docs(components/select): Fix incorrect button variant used in code example

### DIFF
--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -560,7 +560,7 @@ This can be hard to conceptualize, so heres a fairly large example showing how l
 
   <div style="display: flex; gap: 16px;">
     <sl-button type="reset">Reset</sl-button>
-    <sl-button type="submit" variant="brand">Show FormData</sl-button>
+    <sl-button type="submit" variant="primary">Show FormData</sl-button>
   </div>
 
   <br>


### PR DESCRIPTION
#### Description

In a code example in the [Select](https://shoelace.style/components/select) component page, `variant="brand"` was used in a Shoelace button, which isn’t a valid button variant in Shoelace. This pull request fixes it by replacing `variant="brand"` with `variant="primary"`.
