### PR TITLE
feat: support add inline svg icons

### DIFF
--- a/src/components/icon/library.default.ts
+++ b/src/components/icon/library.default.ts
@@ -1,9 +1,20 @@
 import { getBasePath } from '../../utilities/base-path.js';
 import type { IconLibrary } from './library.js';
 
+const inlineIcons: Record<string, string> = {
+}
 const library: IconLibrary = {
   name: 'default',
-  resolver: name => getBasePath(`assets/icons/${name}.svg`)
+  resolver: name => {
+    if (name in inlineIcons) {
+      return `data:image/svg+xml,${encodeURIComponent(inlineIcons[name])}`;
+    } else {
+      return getBasePath(`assets/icons/${name}.svg`)
+    }
+  },
+  add: (name: string, svgData: string) => {
+    (inlineIcons as any)[name] = svgData;
+  }
 };
 
 export default library;

--- a/src/components/icon/library.system.ts
+++ b/src/components/icon/library.system.ts
@@ -127,6 +127,9 @@ const systemLibrary: IconLibrary = {
       return `data:image/svg+xml,${encodeURIComponent(icons[name])}`;
     }
     return '';
+  },
+  add: (name: string, svgData: string) => {
+    (icons as any)[name] = svgData
   }
 };
 

--- a/src/components/icon/library.ts
+++ b/src/components/icon/library.ts
@@ -9,6 +9,8 @@ export interface IconLibrary {
   resolver: IconLibraryResolver;
   mutator?: IconLibraryMutator;
   spriteSheet?: boolean;
+  add: (name: string, svgData: string) => void;
+  inlineIcons?: Record<string, string>
 }
 
 let registry: IconLibrary[] = [defaultLibrary, systemLibrary];
@@ -32,11 +34,22 @@ export function getIconLibrary(name?: string) {
 /** Adds an icon library to the registry, or overrides an existing one. */
 export function registerIconLibrary(name: string, options: Omit<IconLibrary, 'name'>) {
   unregisterIconLibrary(name);
+  const inlineIcons = options.inlineIcons || {};
   registry.push({
     name,
-    resolver: options.resolver,
+    resolver: (name: string) => {
+      if (name in inlineIcons) {
+        return `data:image/svg+xml,${encodeURIComponent(inlineIcons[name])}`;
+      } else {
+        return options.resolver(name)
+      }
+    },
     mutator: options.mutator,
-    spriteSheet: options.spriteSheet
+    spriteSheet: options.spriteSheet,
+    inlineIcons,
+    add: (name: string, svgData: string) => {
+      inlineIcons[name] = svgData;
+    }
   });
 
   // Redraw watched icons


### PR DESCRIPTION

feat: add custom inline `svg` icon

```ts
import { getIconLibrary } from '@shoelace-style/shoelace'
const defaultIcons = getIconLibrary('default')
defaultIcons.add("phone",`<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"/></svg>`)
```
Inline icons embedded with SVG data，This can help the application build in icons。

inline `svg` icon support custom icon library,

```ts
import { getIconLibrary } from '@shoelace-style/shoelace'
const customIcons = registerIconLibrary('xxxx',{
     inlineIcons:{
         phone,`<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke- linejoin="round"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"/></svg>`
  })
```

Inline icons have resolver priority and are resolved using custom resolver only when there is no match




