### PR TITLE
docs(getting-started/form-controls): Fix a link referring to non‐existent heading

### DIFF
--- a/docs/pages/getting-started/form-controls.md
+++ b/docs/pages/getting-started/form-controls.md
@@ -566,5 +566,5 @@ console.log(formControls); // e.g. [input, sl-input, ...]
 ```
 
 :::tip
-You probably don't need this function! If you're gathering form data for submission, you probably want to use [Data Serialization](#data-serializing) instead.
+You probably don't need this function! If you're gathering form data for submission, you probably want to use [Data Serialization](#data-serialization) instead.
 :::


### PR DESCRIPTION
#### Description

In a Getting Started page with title [Form Controls](https://shoelace.style/getting-started/form-controls), the last link on the page at the bottom under heading [“Getting Associated Form Controls”](https://shoelace.style/getting-started/form-controls#getting-associated-form-controls), the callout used there renders a link referring to a # URL, and that points to `#data-serializing`. But I believe at some point, that heading was renamed to “Data Serialization” but a link referring to that heading wasn’t updated to the new heading name.