### PR TITLE
Use data attribute to determine safe triangle position

### DIFF
--- a/src/components/menu-item/submenu-controller.ts
+++ b/src/components/menu-item/submenu-controller.ts
@@ -195,16 +195,16 @@ export class SubmenuController implements ReactiveController {
   private handlePopupReposition = () => {
     const submenuSlot: HTMLSlotElement | null = this.host.renderRoot.querySelector("slot[name='submenu']");
     const menu = submenuSlot?.assignedElements({ flatten: true }).filter(el => el.localName === 'sl-menu')[0];
-    const isRtl = getComputedStyle(this.host).direction === 'rtl';
+    const isOnLeft = this.popupRef.value?.attributes?.['data-current-placement']?.startsWith('left');
     if (!menu) {
       return;
     }
 
     const { left, top, width, height } = menu.getBoundingClientRect();
 
-    this.host.style.setProperty('--safe-triangle-submenu-start-x', `${isRtl ? left + width : left}px`);
+    this.host.style.setProperty('--safe-triangle-submenu-start-x', `${isOnLeft ? left + width : left}px`);
     this.host.style.setProperty('--safe-triangle-submenu-start-y', `${top}px`);
-    this.host.style.setProperty('--safe-triangle-submenu-end-x', `${isRtl ? left + width : left}px`);
+    this.host.style.setProperty('--safe-triangle-submenu-end-x', `${isOnLeft ? left + width : left}px`);
     this.host.style.setProperty('--safe-triangle-submenu-end-y', `${top + height}px`);
   };
 


### PR DESCRIPTION
When the submenu opens to the right, the safe triangle's position is correct.

<img width="515" height="215" alt="image" src="https://github.com/user-attachments/assets/d3890cea-282f-4e92-8e15-218461bea97f" />

But when it gets flipped by the underlying floating-ui library, it becomes incorrect:

<img width="430" height="171" alt="image" src="https://github.com/user-attachments/assets/a64ca976-43bb-4315-99a9-4109132e03d0" />

This is because the code checks for the `direction` style property, which is incorrect - the `data-current-placement` attribute tells the whole story.