### PR TITLE
Add JSDoc documentation for component attributes

### DIFF
--- a/src/components/animation/animation.component.ts
+++ b/src/components/animation/animation.component.ts
@@ -19,6 +19,12 @@ import type { CSSResultGroup } from 'lit';
  *
  * @slot - The element to animate. Avoid slotting in more than one element, as subsequent ones will be ignored. To
  *  animate multiple elements, either wrap them in a single container or use multiple `<sl-animation>` elements.
+ *
+ * @attr {number} end-delay - The number of milliseconds to delay after the active period of an animation sequence.
+ * @attr {number} iteration-start - The offset at which to start the animation, usually between 0 (start) and 1 (end).
+ * @attr {number} playback-rate - Sets the animation's playback rate. The default is `1`, which plays the animation at
+ * a normal speed. Setting this to `2`, for example, will double the animation's speed. A negative value can be used
+ * to reverse the animation. This value can be changed without causing the animation to restart.
  */
 export default class SlAnimation extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/button/button.component.ts
+++ b/src/components/button/button.component.ts
@@ -37,6 +37,13 @@ import type { ShoelaceFormControl } from '../../internal/shoelace-element.js';
  * @csspart suffix - The container that wraps the suffix.
  * @csspart caret - The button's caret icon, an `<sl-icon>` element.
  * @csspart spinner - The spinner that shows when the button is in the loading state.
+ *
+ * @attr {string} formaction - Used to override the form owner's `action` attribute.
+ * @attr {"application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain"} formenctype - Used to override
+ * the form owner's `enctype` attribute.
+ * @attr {"post" | "get"} formmethod - Used to override the form owner's `method` attribute.
+ * @attr {boolean} formnovalidate - Used to override the form owner's `novalidate` attribute.
+ * @attr {string} formtarget - Used to override the form owner's `target` attribute.
  */
 export default class SlButton extends ShoelaceElement implements ShoelaceFormControl {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -46,6 +46,13 @@ import type SlCarouselItem from '../carousel-item/carousel-item.component.js';
  * @cssproperty [--aspect-ratio=16/9] - The aspect ratio of each slide.
  * @cssproperty --scroll-hint - The amount of padding to apply to the scroll area, allowing adjacent slides to become
  *  partially visible as a scroll hint.
+ *
+ * @attr {number} autoplay-interval - Specifies the amount of time, in milliseconds, between each automatic scroll.
+ * @attr {number} slides-per-page - Specifies how many slides should be shown at a given time.
+ * @attr {number} slides-per-move - Specifies the number of slides the carousel will advance when scrolling, useful
+ * when specifying a `slides-per-page` greater than one.
+ * @attr {boolean} mouse-dragging - When set, it is possible to scroll through the slides by dragging them with the
+ * mouse.
  */
 export default class SlCarousel extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/checkbox/checkbox.component.ts
+++ b/src/components/checkbox/checkbox.component.ts
@@ -40,6 +40,8 @@ import type { ShoelaceFormControl } from '../../internal/shoelace-element.js';
  * @csspart indeterminate-icon - The indeterminate icon, an `<sl-icon>` element.
  * @csspart label - The container that wraps the checkbox's label.
  * @csspart form-control-help-text - The help text's wrapper.
+ *
+ * @attr {string} help-text - The checkbox's help text. If you need to display HTML, use the `help-text` slot instead.
  */
 export default class SlCheckbox extends ShoelaceElement implements ShoelaceFormControl {
   static styles: CSSResultGroup = [componentStyles, formControlStyles, styles];

--- a/src/components/color-picker/color-picker.component.ts
+++ b/src/components/color-picker/color-picker.component.ts
@@ -89,6 +89,8 @@ declare const EyeDropper: EyeDropperConstructor;
  * @cssproperty --slider-height - The height of the hue and alpha sliders.
  * @cssproperty --slider-handle-size - The diameter of the slider's handle.
  * @cssproperty --swatch-size - The size of each predefined color swatch.
+ *
+ * @attr {boolean} no-format-toggle - Removes the button that lets users toggle between format.
  */
 export default class SlColorPicker extends ShoelaceElement implements ShoelaceFormControl {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/copy-button/copy-button.component.ts
+++ b/src/components/copy-button/copy-button.component.ts
@@ -40,6 +40,12 @@ import type { CSSResultGroup } from 'lit';
  *
  * @animation copy.in - The animation to use when feedback icons animate in.
  * @animation copy.out - The animation to use when feedback icons animate out.
+ *
+ * @attr {string} copy-label - A custom label to show in the tooltip.
+ * @attr {string} success-label - A custom label to show in the tooltip after copying.
+ * @attr {string} error-label - A custom label to show in the tooltip when a copy error occurs.
+ * @attr {number} feedback-duration - The length of time to show feedback before restoring the default trigger.
+ * @attr {"top" | "right" | "bottom" | "left"} tooltip-placement - The preferred placement of the tooltip.
  */
 export default class SlCopyButton extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/dialog/dialog.component.ts
+++ b/src/components/dialog/dialog.component.ts
@@ -66,6 +66,9 @@ import type { CSSResultGroup } from 'lit';
  * @property modal - Exposes the internal modal utility that controls focus trapping. To temporarily disable focus
  *   trapping and allow third-party modals spawned from an active Shoelace modal, call `modal.activateExternal()` when
  *   the third-party modal opens. Upon closing, call `modal.deactivateExternal()` to restore Shoelace's focus trapping.
+ *
+ * @attr {boolean} no-header - Disables the header. This will also remove the default close button, so please ensure
+ * you provide an easy, accessible way for users to dismiss the dialog.
  */
 export default class SlDialog extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/drawer/drawer.component.ts
+++ b/src/components/drawer/drawer.component.ts
@@ -74,6 +74,9 @@ import type { CSSResultGroup } from 'lit';
  * @property modal - Exposes the internal modal utility that controls focus trapping. To temporarily disable focus
  *   trapping and allow third-party modals spawned from an active Shoelace modal, call `modal.activateExternal()` when
  *   the third-party modal opens. Upon closing, call `modal.deactivateExternal()` to restore Shoelace's focus trapping.
+ *
+ * @attr {boolean} no-header - Disables the header. This will also remove the default close button, so please ensure
+ * you provide an easy, accessible way for users to dismiss the dialog.
  */
 export default class SlDrawer extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/dropdown/dropdown.component.ts
+++ b/src/components/dropdown/dropdown.component.ts
@@ -42,6 +42,9 @@ import type SlMenu from '../menu/menu.js';
  *
  * @animation dropdown.show - The animation to use when showing the dropdown.
  * @animation dropdown.hide - The animation to use when hiding the dropdown.
+ *
+ * @attr {boolean} stay-open-on-select - By default, the dropdown is closed when an item is selected. This
+ * attribute will keep it open instead. Useful for dropdowns that allow for multiple interactions.
  */
 export default class SlDropdown extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/format-date/format-date.component.ts
+++ b/src/components/format-date/format-date.component.ts
@@ -8,6 +8,10 @@ import ShoelaceElement from '../../internal/shoelace-element.js';
  * @documentation https://shoelace.style/components/format-date
  * @status stable
  * @since 2.0
+ *
+ * @attr {"short" | "long"} time-zone-name - The format for displaying the time zone name.
+ * @attr {string} time-zone - The time zone to express the time in.
+ * @attr {"auto" | "12" | "24"} hour-format - The format for displaying the hour.
  */
 export default class SlFormatDate extends ShoelaceElement {
   private readonly localize = new LocalizeController(this);

--- a/src/components/format-number/format-number.component.ts
+++ b/src/components/format-number/format-number.component.ts
@@ -7,6 +7,16 @@ import ShoelaceElement from '../../internal/shoelace-element.js';
  * @documentation https://shoelace.style/components/format-number
  * @status stable
  * @since 2.0
+ *
+ * @attr {boolean} no-grouping - Turns off grouping separators.
+ * @attr {"symbol" | "narrowSymbol" | "code" | "name"} currency-display - How to display the currency.
+ * @attr {number} minimum-integer-digits - The minimum number of integer digits to use. Possible values are 1-21.
+ * @attr {number} minimum-fraction-digits - The minimum number of fraction digits to use. Possible values are 0-20.
+ * @attr {number} maximum-fraction-digits - The maximum number of fraction digits to use. Possible values are 0-20.
+ * @attr {number} minimum-significant-digits - The minimum number of significant digits to use. Possible values are
+ * 1-21.
+ * @attr {number} maximum-significant-digits - The maximum number of significant digits to use. Possible values are
+ * 1-21.
  */
 export default class SlFormatNumber extends ShoelaceElement {
   private readonly localize = new LocalizeController(this);

--- a/src/components/icon/icon.component.ts
+++ b/src/components/icon/icon.component.ts
@@ -27,7 +27,8 @@ interface IconSource {
  * @since 2.0
  *
  * @event sl-load - Emitted when the icon has loaded. When using `spriteSheet: true` this will not emit.
- * @event sl-error - Emitted when the icon fails to load due to an error. When using `spriteSheet: true` this will not emit.
+ * @event sl-error - Emitted when the icon fails to load due to an error. When using `spriteSheet: true` this will not
+ * emit.
  *
  * @csspart svg - The internal SVG element.
  * @csspart use - The <use> element generated when using `spriteSheet: true`

--- a/src/components/include/include.component.ts
+++ b/src/components/include/include.component.ts
@@ -15,6 +15,9 @@ import type { CSSResultGroup } from 'lit';
  *
  * @event sl-load - Emitted when the included file is loaded.
  * @event {{ status: number }} sl-error - Emitted when the included file fails to load due to an error.
+ *
+ * @attr {boolean} allow-scripts - Allows included scripts to be executed. Be sure you trust the content you are
+ * including as it will be executed as code and can result in XSS attacks.
  */
 export default class SlInclude extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/input/input.component.ts
+++ b/src/components/input/input.component.ts
@@ -49,6 +49,12 @@ import type { ShoelaceFormControl } from '../../internal/shoelace-element.js';
  * @csspart clear-button - The clear button.
  * @csspart password-toggle-button - The password toggle button.
  * @csspart suffix - The container that wraps the suffix.
+ *
+ * @attr {string} help-text - The input's help text. If you need to display HTML, use the `help-text` slot instead.
+ * @attr {boolean} password-toggle - Adds a button to toggle the password's visibility. Only applies to password types.
+ * @attr {boolean} password-visible - Determines whether or not the password is currently visible. Only applies to
+ * password input types.
+ * @attr {boolean} no-spin-buttons - Hides the browser's built-in increment/decrement spin buttons for number inputs.
  */
 export default class SlInput extends ShoelaceElement implements ShoelaceFormControl {
   static styles: CSSResultGroup = [componentStyles, formControlStyles, styles];

--- a/src/components/mutation-observer/mutation-observer.component.ts
+++ b/src/components/mutation-observer/mutation-observer.component.ts
@@ -15,6 +15,13 @@ import type { CSSResultGroup } from 'lit';
  * @event {{ mutationList: MutationRecord[] }} sl-mutation - Emitted when a mutation occurs.
  *
  * @slot - The content to watch for mutations.
+ *
+ * @attr {boolean} attr-old-value - Indicates whether or not the attribute's previous value should be recorded when
+ * monitoring changes.
+ * @attr {boolean} char-data - Watches for changes to the character data contained within the node.
+ * @attr {boolean} char-data-old-value - Indicates whether or not the previous value of the node's text should be
+ * recorded.
+ * @attr {boolean} child-list - Watches for the addition or removal of new child nodes.
  */
 export default class SlMutationObserver extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/popup/popup.component.ts
+++ b/src/components/popup/popup.component.ts
@@ -51,6 +51,29 @@ function isVirtualElement(e: unknown): e is VirtualElement {
  * @cssproperty [--auto-size-available-height] - A read-only custom property that determines the amount of height the
  *  popup can be before overflowing. Useful for positioning child elements that need to overflow. This property is only
  *  available when using `auto-size`.
+ *
+ * @attr {"start" | "end" | "center" | "anchor"} arrow-placement - The placement of the arrow. The default is `anchor`,
+ * which will align the arrow as close to the center of the anchor as possible, considering available space and
+ * `arrow-padding`. A value of `start`, `end`, or `center` will align the arrow to the start, end, or center of the
+ * popover instead.
+ * @attr {number} arrow-padding - The amount of padding between the arrow and the edges of the popup. If the popup has a
+ * border-radius, for example, this will prevent it from overflowing the corners.
+ * @attr {string} flip-fallback-placements - If the preferred placement doesn't fit, popup will be tested in these
+ * fallback placements until one fits. Must be a string of any number of placements separated by a space, e.g. "top
+ * bottom left". If no placement fits, the flip fallback strategy will be used instead.
+ * @attr {"start" | "end" | "center" | "anchor"} flip-fallback-strategy - When neither the preferred placement nor the
+ * fallback placements fit, this value will be used to determine whether the popup should be positioned using the best
+ * available fit based on available space or as it was initially preferred.
+ * @attr {number} flip-padding - The amount of padding, in pixels, to exceed before the flip behavior will occur.
+ * @attr {number} shift-padding - The amount of padding, in pixels, to exceed before the shift behavior will occur.
+ * @attr {"horizontal" | "vertical" | "both"} auto-size - When set, this will cause the popup to automatically resize
+ * itself to prevent it from overflowing.
+ * @attr {number} auto-size-padding - The amount of padding, in pixels, to exceed before the auto-size behavior will
+ * occur.
+ * @attr {boolean} hover-bridge - When a gap exists between the anchor and the popup element, this option will add a
+ * "hover bridge" that fills the gap using an invisible element. This makes listening for events such as `mouseenter`
+ * and `mouseleave` more sane because the pointer never technically leaves the element. The hover bridge will only be
+ * drawn when the popover is active.
  */
 export default class SlPopup extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/qr-code/qr-code.component.ts
+++ b/src/components/qr-code/qr-code.component.ts
@@ -15,6 +15,8 @@ import type { CSSResultGroup } from 'lit';
  * @since 2.0
  *
  * @csspart base - The component's base wrapper.
+ *
+ * @attr {"L" | "M" | "Q" | "H"} error-correction - The level of error correction to use.
  */
 export default class SlQrCode extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/radio-group/radio-group.component.ts
+++ b/src/components/radio-group/radio-group.component.ts
@@ -42,6 +42,9 @@ import type SlRadioButton from '../radio-button/radio-button.js';
  * @csspart form-control-help-text - The help text's wrapper.
  * @csspart button-group - The button group that wraps radio buttons.
  * @csspart button-group__base - The button group's `base` part.
+ *
+ * @attr {string} help-text - The radio group's help text. If you need to display HTML, use the `help-text` slot
+ * instead.
  */
 export default class SlRadioGroup extends ShoelaceElement implements ShoelaceFormControl {
   static styles: CSSResultGroup = [componentStyles, formControlStyles, styles];

--- a/src/components/range/range.component.ts
+++ b/src/components/range/range.component.ts
@@ -44,6 +44,8 @@ import type { ShoelaceFormControl } from '../../internal/shoelace-element.js';
  * @cssproperty --track-color-inactive - The of the portion of the track that represents the remaining value.
  * @cssproperty --track-height - The height of the track.
  * @cssproperty --track-active-offset - The point of origin of the active track.
+ *
+ * @attr {string} help-text - The range's help text. If you need to display HTML, use the `help-text` slot instead.
  */
 export default class SlRange extends ShoelaceElement implements ShoelaceFormControl {
   static styles: CSSResultGroup = [componentStyles, formControlStyles, styles];

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -68,6 +68,12 @@ import type SlOption from '../option/option.component.js';
  * @csspart tag__remove-button__base - The tag's remove button base part.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
+ *
+ * @attr {string} value - The default value of the form control. Primarily used for resetting the form control.
+ * @attr {number} max-options-visible - The maximum number of selected options to show when `multiple` is true. After
+ * the maximum, "+n" will be shown to indicate the number of additional items that are selected. Set to 0 to remove the
+ * limit.
+ * @attr {string} help-text - The select's help text. If you need to display HTML, use the `help-text` slot instead.
  */
 export default class SlSelect extends ShoelaceElement implements ShoelaceFormControl {
   static styles: CSSResultGroup = [componentStyles, formControlStyles, styles];

--- a/src/components/split-panel/split-panel.component.ts
+++ b/src/components/split-panel/split-panel.component.ts
@@ -51,6 +51,10 @@ export const SNAP_NONE = () => null;
  *  usually wider than the divider to facilitate easier dragging.
  * @cssproperty [--min=0] - The minimum allowed size of the primary panel.
  * @cssproperty [--max=100%] - The maximum allowed size of the primary panel.
+ *
+ * @attr {number} position-in-pixels - The current position of the divider from the primary panel's edge in pixels.
+ * @attr {string} primary-panel - Designates which panel is the primary panel. The primary panel will be constrained by
+ * the `min` and `max` properties.
  */
 export default class SlSplitPanel extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/switch/switch.component.ts
+++ b/src/components/switch/switch.component.ts
@@ -38,6 +38,8 @@ import type { ShoelaceFormControl } from '../../internal/shoelace-element.js';
  * @cssproperty --width - The width of the switch.
  * @cssproperty --height - The height of the switch.
  * @cssproperty --thumb-size - The size of the thumb.
+ *
+ * @attr {string} help-text - The switch's help text. If you need to display HTML, use the `help-text` slot instead.
  */
 export default class SlSwitch extends ShoelaceElement implements ShoelaceFormControl {
   static styles: CSSResultGroup = [componentStyles, formControlStyles, styles];

--- a/src/components/tab-group/tab-group.component.ts
+++ b/src/components/tab-group/tab-group.component.ts
@@ -41,6 +41,9 @@ import type SlTabPanel from '../tab-panel/tab-panel.js';
  * @cssproperty --indicator-color - The color of the active tab indicator.
  * @cssproperty --track-color - The color of the indicator's track (the line that separates tabs from panels).
  * @cssproperty --track-width - The width of the indicator's track (the line that separates tabs from panels).
+ *
+ * @attr {boolean} no-scroll-controls - Disables the scroll arrows that appear when tabs overflow.
+ * @attr {boolean} fixed-scroll-controls - Prevent scroll buttons from being hidden when inactive.
  */
 export default class SlTabGroup extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/textarea/textarea.component.ts
+++ b/src/components/textarea/textarea.component.ts
@@ -35,6 +35,8 @@ import type { ShoelaceFormControl } from '../../internal/shoelace-element.js';
  * @csspart form-control-help-text - The help text's wrapper.
  * @csspart base - The component's base wrapper.
  * @csspart textarea - The internal `<textarea>` control.
+ *
+ * @attr {string} help-text - The textarea's help text. If you need to display HTML, use the `help-text` slot instead.
  */
 export default class SlTextarea extends ShoelaceElement implements ShoelaceFormControl {
   static styles: CSSResultGroup = [componentStyles, formControlStyles, styles];


### PR DESCRIPTION
This adds documentation for component attributes whose names are different from their corresponding property, following [Custom Elements Manifest](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/#supported-jsdoc).

These attributes are used by [analyzers](https://github.com/runem/web-component-analyzer) to provide autocompletion, validation, and intellisense-like features for Shoelace components.