### PR TITLE
fix(button): preserve value on form reset

### DIFF
--- a/src/components/button/button.component.ts
+++ b/src/components/button/button.component.ts
@@ -104,6 +104,9 @@ export default class SlButton extends ShoelaceElement implements ShoelaceFormCon
    */
   @property() value = '';
 
+  /** The default value of the button, used when resetting the form. Set to the initial value when the component is first updated. */
+  defaultValue = '';
+
   /** When set, the underlying button will be rendered as an `<a>` with this `href` instead of a `<button>`. */
   @property() href = '';
 
@@ -165,6 +168,9 @@ export default class SlButton extends ShoelaceElement implements ShoelaceFormCon
     if (this.isButton()) {
       this.formControlController.updateValidity();
     }
+
+    // Store the initial value as the default value for form reset
+    this.defaultValue = this.value;
   }
 
   private handleBlur() {

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -264,6 +264,27 @@ describe('<sl-button>', () => {
       expect(submitter.formTarget).to.equal('_blank');
       expect(submitter.formNoValidate).to.be.true;
     });
+
+    it('should preserve the button value when the form is reset', async () => {
+      const el = await fixture(html`
+        <form>
+          <sl-button type="submit" name="action" value="save">Save</sl-button>
+          <sl-button type="reset">Reset</sl-button>
+        </form>
+      `);
+      const submitButton = el.querySelector<SlButton>('sl-button[type="submit"]')!;
+      const resetButton = el.querySelector<SlButton>('sl-button[type="reset"]')!;
+
+      // Verify initial value
+      expect(submitButton.value).to.equal('save');
+
+      // Reset the form
+      resetButton.click();
+      await submitButton.updateComplete;
+
+      // Value should still be 'save' after reset
+      expect(submitButton.value).to.equal('save');
+    });
   });
 
   describe('when using methods', () => {


### PR DESCRIPTION
## Summary
Fixes #2524

## Problem
When a form containing `<sl-button>` elements with `name`/`value` attributes is reset, the button values were being cleared instead of being preserved.

For example:
```html
<form>
  <sl-button type='submit' name='rtype' value='month'>List by month</sl-button>
  <sl-button type='reset'>Reset</sl-button>
</form>
```

After clicking the reset button, the submit button's `value` would become empty.

## Root Cause
The `FormControlController.handleFormReset()` method calls `setValue(host, defaultValue(host))` to restore form controls to their default values. However, `sl-button` didn't have a `defaultValue` property, so `defaultValue(host)` returned `undefined`, which was then set as the value.

## Fix
Added a `defaultValue` property to `sl-button` that is initialized to the button's `value` in `firstUpdated()`. This ensures that:
1. The initial value from the HTML attribute is captured as the default
2. Form reset restores the button to this initial value

This matches the native HTML behavior where button values are fixed in the markup and don't change on form reset.

## Testing
Added a test case to verify the button value is preserved after form reset.