### PR TITLE
fix(carousel): remove row-gap when pagination is disabled

### DIFF
--- a/src/components/carousel/carousel.styles.ts
+++ b/src/components/carousel/carousel.styles.ts
@@ -23,6 +23,11 @@ export default css`
     position: relative;
   }
 
+  /* Remove row-gap when pagination is not enabled to avoid extra space below the slides */
+  :host(:not([pagination])) .carousel {
+    row-gap: 0;
+  }
+
   .carousel__pagination {
     grid-area: pagination;
     display: flex;


### PR DESCRIPTION
## Summary

Fixes #2485

## Problem

sl-carousel renders its internal ase as a CSS Grid with two row tracks:

\\\css
.carousel {
  display: grid;
  grid-template-rows: 1fr min-content;          /* slides | pagination */
  grid-template-areas: '. slides .' '. pagination .';
  gap: var(--sl-spacing-medium);                /* applies row-gap unconditionally */
}
\\\

When the \pagination\ attribute is **not** set (the default), the pagination \<div>\ is never rendered into the DOM. However, the CSS Grid still has two defined row tracks, and \gap\ (which includes \ow-gap\) applies between **all** adjacent tracks regardless of whether the second track has content. The empty \min-content\ row is height 0, but the gap between track 1 and track 2 persists — creating a visible space of \ar(--sl-spacing-medium)\ below the carousel slides.

## Fix

Add a single rule that resets \ow-gap\ to \