### PR TITLE
fix(tab-group): ensure indicator is visible with 1px track-width

### DIFF
--- a/.branch_name
+++ b/.branch_name
@@ -1,0 +1,1 @@
+fix/issue-2415-tab-indicator-track-width

--- a/src/components/tab-group/tab-group.styles.ts
+++ b/src/components/tab-group/tab-group.styles.ts
@@ -21,6 +21,7 @@ export default css`
 
   .tab-group__indicator {
     position: absolute;
+    box-sizing: content-box;
     transition:
       var(--sl-transition-fast) translate ease,
       var(--sl-transition-fast) width ease;


### PR DESCRIPTION
Fixes #2415

## Summary
The tab group indicator was invisible when `--track-width` was set to 1px. This was caused by `box-sizing: border-box` (inherited from component styles) which drew the border inside the indicator element's 0-height content area, making it effectively hidden.

## Changes
- Added `box-sizing: content-box` to `.tab-group__indicator` in `src/components/tab-group/tab-group.styles.ts` to ensure the border extends outside the content area and remains visible regardless of track-width value.

## Testing
Verified that the fix allows the indicator border to render properly when `--track-width` is set to 1px (or any value), as the border now extends beyond the element's content box rather than being clipped inside it.

```bash
git diff --stat HEAD~1
 src/components/tab-group/tab-group.styles.ts | 1 +
 1 file changed, 1 insertion(+)
```